### PR TITLE
Support headers and bodies in privileged requests

### DIFF
--- a/Sources/MusanovaKit/Requests/MusicPrivilegedDataRequest.swift
+++ b/Sources/MusanovaKit/Requests/MusicPrivilegedDataRequest.swift
@@ -18,7 +18,7 @@ public enum HTTPMethod: String, Sendable {
 }
 
 /// A custom request for loading data from an arbitrary Apple Music private API endpoint.
-public struct MusicPrivilegedDataRequest {
+public struct MusicPrivilegedDataRequest: Sendable {
     /// The privileged developer token for Apple Music API.
     private let developerToken: String
 
@@ -28,34 +28,57 @@ public struct MusicPrivilegedDataRequest {
     /// The HTTP method for the request.
     private let method: HTTPMethod
 
+    /// Headers to add after the standard Apple Music headers.
+    private let headers: [String: String]
+
+    /// The optional HTTP request body.
+    private let body: Data?
+
     /// Creates a data request with a URL request.
     ///
     /// - Parameters:
     ///   - url: The URL for the data request.
     ///   - developerToken: The privileged developer token for Apple Music API. Must not be empty.
     ///   - method: The HTTP method for the request. Defaults to `.get`.
-    public init(url: URL, developerToken: String, method: HTTPMethod = .get) {
+    ///   - headers: Additional HTTP headers for the request.
+    ///   - body: An optional HTTP body, such as encoded JSON.
+    public init(
+        url: URL,
+        developerToken: String,
+        method: HTTPMethod = .get,
+        headers: [String: String] = [:],
+        body: Data? = nil
+    ) {
         self.url = url
         self.developerToken = developerToken
         self.method = method
+        self.headers = headers
+        self.body = body
     }
 
     /// Fetches data from the Apple Music private API endpoint that the URL request defines.
     public func response() async throws -> MusicDataResponse {
+        let urlRequest = makeURLRequest()
+        let request = MusicDeveloperRequest(urlRequest: urlRequest, developerToken: developerToken)
+
+        return try await request.response()
+    }
+
+    func makeURLRequest() -> URLRequest {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method.rawValue
+        urlRequest.httpBody = body
 
-        // Set Origin header
         urlRequest.setValue("https://music.apple.com", forHTTPHeaderField: "Origin")
 
-        // Set Host header - important for Apple Music API
         if let host = url.host {
             urlRequest.setValue(host, forHTTPHeaderField: "Host")
         }
 
-        let request = MusicDeveloperRequest(urlRequest: urlRequest, developerToken: developerToken)
+        for (name, value) in headers {
+            urlRequest.setValue(value, forHTTPHeaderField: name)
+        }
 
-        let response = try await request.response()
-        return response
+        return urlRequest
     }
 }

--- a/Tests/MusanovaKitTests/MusicPrivilegedDataRequestTests.swift
+++ b/Tests/MusanovaKitTests/MusicPrivilegedDataRequestTests.swift
@@ -1,0 +1,48 @@
+//
+//  MusicPrivilegedDataRequestTests.swift
+//  MusanovaKitTests
+//
+
+import Foundation
+import Testing
+
+@testable import MusanovaKit
+
+@Suite
+struct MusicPrivilegedDataRequestTests {
+  @Test
+  func buildsRequestWithMethodHeadersAndBody() throws {
+    let url = try #require(URL(string: "https://amp-api.music.apple.com/v1/me/test"))
+    let body = Data(#"{"name":"Mix"}"#.utf8)
+    let request = MusicPrivilegedDataRequest(
+      url: url,
+      developerToken: "developer-token",
+      method: .patch,
+      headers: [
+        "Content-Type": "application/json",
+        "X-Test": "value"
+      ],
+      body: body
+    ).makeURLRequest()
+
+    #expect(request.url == url)
+    #expect(request.httpMethod == "PATCH")
+    #expect(request.httpBody == body)
+    #expect(request.value(forHTTPHeaderField: "Origin") == "https://music.apple.com")
+    #expect(request.value(forHTTPHeaderField: "Host") == "amp-api.music.apple.com")
+    #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    #expect(request.value(forHTTPHeaderField: "X-Test") == "value")
+  }
+
+  @Test
+  func keepsExistingDefaults() throws {
+    let url = try #require(URL(string: "https://amp-api.music.apple.com/v1/test"))
+    let request = MusicPrivilegedDataRequest(
+      url: url,
+      developerToken: "developer-token"
+    ).makeURLRequest()
+
+    #expect(request.httpMethod == "GET")
+    #expect(request.httpBody == nil)
+  }
+}


### PR DESCRIPTION
## What changed

Extends the existing `MusicPrivilegedDataRequest` with two missing inputs: custom headers and an optional request body. The default GET behavior and current callers stay unchanged.

The request-building step now has direct tests for the HTTP method, body, Apple Music headers, and caller-supplied headers.

## Why

Pins, social actions, and taste preferences need JSON bodies or endpoint-specific headers. The existing privileged request type already owns this work, so it should handle those cases without a second client abstraction.

## Checks

- `swift test` (56 tests passed)
- SwiftLint on both changed files (0 violations)
- `git diff --check`