### PR TITLE
Expose raw, parsed, and timed lyrics APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When you call MusanovaKit from a signed-in MusicKit app, the system automaticall
 
 ## Lyrics
 
-`MCatalog.lyrics(for:developerToken:)` fetches the syllable-lyrics TTML feed for a given song. The parser extracts both plain text and per-segment timing metadata.
+MusanovaKit can return the original TTML, parsed paragraphs, or a flat list of timed segments. `MCatalog.lyrics(for:developerToken:)` remains available and returns the parsed paragraphs.
 
 ### Fetching TTML lyrics
 
@@ -97,6 +97,28 @@ line?.segments.forEach { segment in
 
 Use the segment timings to drive your own lyric highlighting, karaoke bars, or subtitle cues. Segments default to a `startTime` of `0` if the TTML omits the `begin` attribute.
 
+Fetch the segments directly when paragraph and line grouping isn't needed:
+
+```swift
+let segments = try await MCatalog.timedLyrics(for: song, developerToken: token)
+
+for segment in segments {
+    print("\(segment.startTime): \(segment.text)")
+}
+```
+
+`MCatalog.parsedLyrics(for:developerToken:countryCode:)` returns the grouped paragraphs explicitly. Both methods accept an optional storefront country code; without one, MusicKit resolves the current storefront.
+
+### Raw TTML
+
+Use `rawLyrics` when you need Apple Music's original document:
+
+```swift
+let ttml = try await MCatalog.rawLyrics(for: song, developerToken: token)
+```
+
+To decode the complete resource, including its playback parameters, call `lyricsResponse` instead.
+
 ### Direct lyric requests
 
 If you need the raw TTML, instantiate `MusicLyricsRequest` directly:
@@ -108,6 +130,13 @@ let ttml = response.data.first?.attributes.ttml
 ```
 
 `MusicLyricsRequest` automatically targets the `/syllable-lyrics` endpoint and decodes the `MusicLyricsResponse` payload.
+
+You can also parse TTML obtained elsewhere. `parse` returns an empty array for malformed input, while `parseValidating` throws `MusanovaKitError.invalidResponseFormat`:
+
+```swift
+let paragraphs = try LyricsParser().parseValidating(ttml)
+let segments = paragraphs.timedSegments
+```
 
 ## Replay and Summaries
 

--- a/Sources/MusanovaKit/Lyrics/LyricParagraph.swift
+++ b/Sources/MusanovaKit/Lyrics/LyricParagraph.swift
@@ -31,3 +31,10 @@ public struct LyricParagraph: Identifiable, Sendable {
         self.songPart = songPart
     }
 }
+
+public extension Collection where Element == LyricParagraph {
+  /// All timed segments in paragraph and line order.
+  var timedSegments: LyricSegments {
+    flatMap(\.lines).flatMap(\.segments)
+  }
+}

--- a/Sources/MusanovaKit/Lyrics/LyricSegment.swift
+++ b/Sources/MusanovaKit/Lyrics/LyricSegment.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// A collection of timed lyric segments in playback order.
+public typealias LyricSegments = [LyricSegment]
+
 /// Represents a timed segment of a lyric line.
 public struct LyricSegment: Identifiable, Sendable {
   /// A unique identifier for the lyric segment.

--- a/Sources/MusanovaKit/Lyrics/LyricsParser.swift
+++ b/Sources/MusanovaKit/Lyrics/LyricsParser.swift
@@ -56,8 +56,17 @@ public class LyricsParser: NSObject, XMLParserDelegate {
   /// Parses the given XML string into an array of `LyricParagraph` objects.
   ///
   /// - Parameter xmlString: The TTML lyrics string to parse.
+  /// - Returns: An array of parsed `LyricParagraph` objects. Invalid TTML returns an empty array.
+  public func parse(_ xmlString: String) -> LyricParagraphs {
+    (try? parseValidating(xmlString)) ?? []
+  }
+
+  /// Parses TTML and reports malformed input to the caller.
+  ///
+  /// - Parameter xmlString: The TTML lyrics string to parse.
   /// - Returns: An array of parsed `LyricParagraph` objects.
-  func parse(_ xmlString: String) -> [LyricParagraph] {
+  /// - Throws: `MusanovaKitError.invalidResponseFormat` when the string is not valid TTML.
+  public func parseValidating(_ xmlString: String) throws -> LyricParagraphs {
     paragraphs = []
     currentParagraph = []
     currentSongPart = nil
@@ -68,11 +77,17 @@ public class LyricsParser: NSObject, XMLParserDelegate {
     currentSegmentText = ""
     hasPendingWhitespace = false
     elementStack = []
-    if let data = xmlString.data(using: .utf8) {
-      let parser = XMLParser(data: data)
-      parser.delegate = self
-      parser.parse()
+    guard let data = xmlString.data(using: .utf8) else {
+      throw MusanovaKitError.invalidResponseFormat(description: "The lyrics TTML is not valid UTF-8.")
     }
+
+    let parser = XMLParser(data: data)
+    parser.delegate = self
+    guard parser.parse() else {
+      let description = parser.parserError?.localizedDescription ?? "The XML parser rejected the document."
+      throw MusanovaKitError.invalidResponseFormat(description: "Invalid lyrics TTML: \(description)")
+    }
+
     return paragraphs
   }
 
@@ -174,7 +189,7 @@ public class LyricsParser: NSObject, XMLParserDelegate {
 
     var hours = 0
     var minutes = 0
-    var secondsComponent = components.last!
+    guard var secondsComponent = components.last else { return nil }
 
     switch components.count {
     case 3:

--- a/Sources/MusanovaKit/Lyrics/MusicLyricsRequest.swift
+++ b/Sources/MusanovaKit/Lyrics/MusicLyricsRequest.swift
@@ -166,7 +166,7 @@ public extension MCatalog {
       return []
     }
 
-    return try LyricsParser().parseValidating(ttml)
+    return LyricsParser().parse(ttml)
   }
 
   /// Fetches the timed lyric segments for a song in document order.

--- a/Sources/MusanovaKit/Lyrics/MusicLyricsRequest.swift
+++ b/Sources/MusanovaKit/Lyrics/MusicLyricsRequest.swift
@@ -9,25 +9,39 @@ import Foundation
 
 /// Represents an error response from the Apple Music API.
 public struct MusicErrorResponse: Codable, Sendable {
-  let errors: [MusicError]
+  public let errors: [MusicError]
+
+  /// Creates an Apple Music error response.
+  public init(errors: [MusicError]) {
+    self.errors = errors
+  }
 }
 
 /// Represents a single error from the Apple Music API.
 public struct MusicError: Codable, Sendable {
-  let id: String
-  let title: String
-  let detail: String
-  let status: String
-  let code: String
+  public let id: String
+  public let title: String
+  public let detail: String
+  public let status: String
+  public let code: String
+
+  /// Creates an Apple Music error.
+  public init(id: String, title: String, detail: String, status: String, code: String) {
+    self.id = id
+    self.title = title
+    self.detail = detail
+    self.status = status
+    self.code = code
+  }
 }
 
 /// A request object used to fetch lyrics for a specified song.
-struct MusicLyricsRequest {
+public struct MusicLyricsRequest: Sendable {
   /// The identifier of the song.
-  let songID: MusicItemID
+  public let songID: MusicItemID
 
   /// The privileged developer token used to authorize the request.
-  let developerToken: String
+  public let developerToken: String
 
   /// Initializes a new lyrics request.
   ///
@@ -35,7 +49,7 @@ struct MusicLyricsRequest {
   ///   - songID: The identifier of the song.
   ///   - developerToken: The privileged developer token used to authorize the request. Must not be empty.
   /// - Throws: `MusanovaKitError.missingDeveloperToken` if the developer token is empty.
-  init(songID: MusicItemID, developerToken: String) throws {
+  public init(songID: MusicItemID, developerToken: String) throws {
     guard !developerToken.isEmpty else {
       throw MusanovaKitError.missingDeveloperToken
     }
@@ -46,7 +60,7 @@ struct MusicLyricsRequest {
   /// Sends the request and returns a response object containing the fetched lyrics.
   ///
   /// - Returns: A `LyricsResponse` object.
-  func response(countryCode: String? = nil) async throws -> MusicLyricsResponse {
+  public func response(countryCode: String? = nil) async throws -> MusicLyricsResponse {
     let url = try await lyricsEndpointURL(countryCode: countryCode)
     let request = MusicPrivilegedDataRequest(url: url, developerToken: developerToken)
 
@@ -112,6 +126,63 @@ extension MusicLyricsRequest {
 }
 
 public extension MCatalog {
+  /// Fetches the decoded response for a song's syllable lyrics.
+  static func lyricsResponse(
+    for song: Song,
+    developerToken: String,
+    countryCode: String? = nil
+  ) async throws -> MusicLyricsResponse {
+    let request = try MusicLyricsRequest(songID: song.id, developerToken: developerToken)
+    return try await request.response(countryCode: countryCode)
+  }
+
+  /// Fetches the raw TTML for a song.
+  ///
+  /// Returns `nil` when the response has no lyrics resource.
+  static func rawLyrics(
+    for song: Song,
+    developerToken: String,
+    countryCode: String? = nil
+  ) async throws -> String? {
+    let response = try await lyricsResponse(
+      for: song,
+      developerToken: developerToken,
+      countryCode: countryCode
+    )
+    return response.rawTTML
+  }
+
+  /// Fetches and parses a song's TTML into paragraphs and lines.
+  static func parsedLyrics(
+    for song: Song,
+    developerToken: String,
+    countryCode: String? = nil
+  ) async throws -> LyricParagraphs {
+    guard let ttml = try await rawLyrics(
+      for: song,
+      developerToken: developerToken,
+      countryCode: countryCode
+    ) else {
+      return []
+    }
+
+    return try LyricsParser().parseValidating(ttml)
+  }
+
+  /// Fetches the timed lyric segments for a song in document order.
+  static func timedLyrics(
+    for song: Song,
+    developerToken: String,
+    countryCode: String? = nil
+  ) async throws -> LyricSegments {
+    let paragraphs = try await parsedLyrics(
+      for: song,
+      developerToken: developerToken,
+      countryCode: countryCode
+    )
+    return paragraphs.timedSegments
+  }
+
   /// Fetches and parses the lyrics for a specified song.
   ///
   /// This method performs the following steps:
@@ -145,17 +216,6 @@ public extension MCatalog {
   /// - Important: Ensure that you have the necessary permissions and a valid developer token
   ///   before calling this method. Unauthorized or incorrect usage may result in errors or empty results.
   static func lyrics(for song: Song, developerToken: String) async throws -> LyricParagraphs {
-    guard !developerToken.isEmpty else {
-      throw MusanovaKitError.missingDeveloperToken
-    }
-    let request = try MusicLyricsRequest(songID: song.id, developerToken: developerToken)
-    let response = try await request.response()
-
-    guard let lyricsString = response.data.first?.attributes.ttml else {
-      return []
-    }
-
-    let parser = LyricsParser()
-    return parser.parse(lyricsString)
+    try await parsedLyrics(for: song, developerToken: developerToken)
   }
 }

--- a/Sources/MusanovaKit/Lyrics/MusicLyricsResponse.swift
+++ b/Sources/MusanovaKit/Lyrics/MusicLyricsResponse.swift
@@ -10,41 +10,72 @@ import Foundation
 /// Represents the response containing lyrics data.
 public struct MusicLyricsResponse: Codable, Sendable {
   /// An array of `LyricsData` objects containing the lyrics information.
-  let data: [LyricsData]
+  public let data: [LyricsData]
+
+  /// Creates a lyrics response.
+  public init(data: [LyricsData]) {
+    self.data = data
+  }
+
+  /// The first lyrics resource's raw TTML, when available.
+  public var rawTTML: String? {
+    data.first?.attributes.ttml
+  }
 }
 
 /// Represents the data for a single lyrics item.
 public struct LyricsData: Codable, Sendable {
   /// The unique identifier for the lyrics item.
-  let id: String
+  public let id: String
 
   /// The type of the lyrics item.
-  let type: String
+  public let type: String
 
   /// The attributes containing the actual lyrics content and play parameters.
-  let attributes: LyricsAttributes
+  public let attributes: LyricsAttributes
+
+  /// Creates a lyrics data resource.
+  public init(id: String, type: String, attributes: LyricsAttributes) {
+    self.id = id
+    self.type = type
+    self.attributes = attributes
+  }
 }
 
 /// Contains the lyrics content and play parameters.
 public struct LyricsAttributes: Codable, Sendable {
   /// The lyrics content in TTML (Timed Text Markup Language) format.
-  let ttml: String
+  public let ttml: String
 
   /// Parameters related to playing the lyrics.
-  let playParams: PlayParams
+  public let playParams: PlayParams
+
+  /// Creates lyrics attributes.
+  public init(ttml: String, playParams: PlayParams) {
+    self.ttml = ttml
+    self.playParams = playParams
+  }
 }
 
 /// Represents parameters for playing the lyrics.
 public struct PlayParams: Codable, Sendable {
   /// The unique identifier for the play parameters.
-  let id: String
+  public let id: String
 
   /// The kind of play parameters.
-  let kind: String
+  public let kind: String
 
   /// The catalog identifier associated with these play parameters.
-  let catalogId: String
+  public let catalogId: String
 
   /// An integer representing the display type for the lyrics.
-  let displayType: Int
+  public let displayType: Int
+
+  /// Creates lyrics playback parameters.
+  public init(id: String, kind: String, catalogId: String, displayType: Int) {
+    self.id = id
+    self.kind = kind
+    self.catalogId = catalogId
+    self.displayType = displayType
+  }
 }

--- a/Tests/MusanovaKitTests/Lyrics/LyricsPublicAPITests.swift
+++ b/Tests/MusanovaKitTests/Lyrics/LyricsPublicAPITests.swift
@@ -1,0 +1,54 @@
+import MusanovaKit
+import MusicKit
+import Testing
+
+struct LyricsPublicAPITests {
+  @Test
+  func responseExposesRawTTMLAndPlaybackMetadata() throws {
+    let playParams = PlayParams(
+      id: "song-id",
+      kind: "song",
+      catalogId: "catalog-id",
+      displayType: 1
+    )
+    let attributes = LyricsAttributes(ttml: "<tt></tt>", playParams: playParams)
+    let lyricsData = LyricsData(id: "lyrics-id", type: "syllable-lyrics", attributes: attributes)
+    let response = MusicLyricsResponse(data: [lyricsData])
+
+    #expect(response.rawTTML == "<tt></tt>")
+    #expect(response.data.first?.id == "lyrics-id")
+    #expect(response.data.first?.attributes.playParams.catalogId == "catalog-id")
+  }
+
+  @Test
+  func parserAndTimedSegmentsAreAvailableWithoutTestableImport() throws {
+    let ttml = """
+      <tt xmlns="http://www.w3.org/ns/ttml">
+        <body>
+          <div>
+            <p><span begin="0.2" end="0.5">Hello</span></p>
+          </div>
+        </body>
+      </tt>
+      """
+
+    let paragraphs = try LyricsParser().parseValidating(ttml)
+
+    #expect(paragraphs.first?.lines.first?.text == "Hello")
+    #expect(paragraphs.timedSegments.map(\.text) == ["Hello"])
+  }
+
+  @Test
+  func validatingParserRejectsMalformedTTML() {
+    #expect(throws: MusanovaKitError.self) {
+      try LyricsParser().parseValidating("<tt><body></tt>")
+    }
+  }
+
+  @Test
+  func directRequestRejectsAnEmptyToken() {
+    #expect(throws: MusanovaKitError.self) {
+      try MusicLyricsRequest(songID: MusicItemID("song-id"), developerToken: "")
+    }
+  }
+}


### PR DESCRIPTION
## What changed

The lyrics code now has public entry points for the three representations callers need: raw TTML, parsed paragraphs, and a flat list of timed segments. `MCatalog.lyrics(for:developerToken:)` keeps its existing signature and delegates to the parsed path.

`MusicLyricsRequest` and its decoded response are now usable outside the package. The response models expose their fields and initializers, while `rawTTML` provides the common shortcut. `LyricsParser` also has a public forgiving parser plus `parseValidating` for callers that need malformed TTML reported as an error.

I added API documentation and README examples covering each path. The focused tests deliberately import `MusanovaKit` without `@testable`, which catches the access-control mismatch that prompted this change.

## Why

The README already told callers to instantiate `MusicLyricsRequest`, but the type, initializer, response method, and useful response properties were internal. That sample couldn't compile in an app. This PR makes the documented lower-level route real and gives high-level callers named APIs instead of requiring them to unpack response models themselves.

## Checks

- `swift test` (58 tests)
- `swiftlint lint --strict` (0 violations)
- `swift package dump-symbol-graph --minimum-access-level public`
