### PR TITLE
Add library pin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ MusanovaKit lets you explore Apple Music features that are not exposed through t
 - [Library Pins](#library-pins)
   - [Fetching pinned items](#fetching-pinned-items)
   - [Custom pin requests](#custom-pin-requests)
+  - [Pinning and unpinning items](#pinning-and-unpinning-items)
+  - [Reordering pins and changing playback](#reordering-pins-and-changing-playback)
 - [Disclaimer](#disclaimer)
 
 ## Requirements
@@ -210,6 +212,26 @@ try await MLibrary.unpin(artist, developerToken: token)
 ```
 
 All `Album`, `Song`, `Playlist`, and `Artist` types conform to the `Pinnable` protocol, allowing them to be used with the `pin(_:developerToken:)` and `unpin(_:developerToken:)` methods.
+
+### Reordering pins and changing playback
+
+Pins can be moved after another pin or straight to the top. Albums and playlists can also use play or shuffle as their default action.
+
+```swift
+try await MLibrary.movePin(
+    withID: pinID,
+    afterPinWithID: precedingPinID,
+    developerToken: token
+)
+
+try await MLibrary.movePinToTop(withID: pinID, developerToken: token)
+
+try await MLibrary.setPlaybackAction(
+    .shuffle,
+    forPinWithID: pinID,
+    developerToken: token
+)
+```
 
 The `Pinnable` protocol is defined as:
 

--- a/Sources/MusanovaKit/Library/Pins/LibraryPin.swift
+++ b/Sources/MusanovaKit/Library/Pins/LibraryPin.swift
@@ -68,6 +68,11 @@ public struct LibraryPinAction: Decodable, Sendable {
   /// - "shuffle": Shuffle play the item (playlists)
   public let action: String
 
+  /// A typed representation of `action` when its value is known to MusanovaKit.
+  public var actionKind: LibraryPinActionKind? {
+    LibraryPinActionKind(rawValue: action)
+  }
+
   /// A unique identifier for the position of this pin.
   public let positionUUID: String
 
@@ -75,6 +80,18 @@ public struct LibraryPinAction: Decodable, Sendable {
     case action
     case positionUUID
   }
+}
+
+/// Actions reported by Apple Music for a library pin.
+public enum LibraryPinActionKind: String, Codable, Sendable {
+  /// Navigates into the pinned resource.
+  case drillIn
+
+  /// Plays the pinned resource in its natural order.
+  case play
+
+  /// Shuffles the contents of the pinned resource.
+  case shuffle
 }
 
 /// Extension to handle the nested meta.libraryPin structure.

--- a/Sources/MusanovaKit/Library/Pins/MLibrary+Pins.swift
+++ b/Sources/MusanovaKit/Library/Pins/MLibrary+Pins.swift
@@ -164,6 +164,64 @@ public extension MLibrary {
     try await unpin(itemId: item.id.rawValue, developerToken: developerToken)
   }
 
+  /// Moves a pin immediately after another pin.
+  ///
+  /// - Parameters:
+  ///   - pinID: The identifier of the pin to move.
+  ///   - precedingPinID: The identifier of the pin that should precede the moved pin.
+  ///   - developerToken: The privileged developer token used to authorize the request.
+  ///
+  /// - Note: This endpoint requires a privileged developer token and access to private Apple Music APIs.
+  static func movePin(
+    withID pinID: String,
+    afterPinWithID precedingPinID: String,
+    developerToken: String
+  ) async throws {
+    let request = try MusicLibraryPinMutationRequest(
+      pinID: pinID,
+      developerToken: developerToken,
+      mutation: .move(afterPinID: precedingPinID)
+    )
+    try await request.response()
+  }
+
+  /// Moves a pin to the first position in the user's pinned items.
+  ///
+  /// - Parameters:
+  ///   - pinID: The identifier of the pin to move.
+  ///   - developerToken: The privileged developer token used to authorize the request.
+  ///
+  /// - Note: This endpoint requires a privileged developer token and access to private Apple Music APIs.
+  static func movePinToTop(withID pinID: String, developerToken: String) async throws {
+    let request = try MusicLibraryPinMutationRequest(
+      pinID: pinID,
+      developerToken: developerToken,
+      mutation: .move(afterPinID: nil)
+    )
+    try await request.response()
+  }
+
+  /// Changes the playback behavior used when a pin is selected.
+  ///
+  /// - Parameters:
+  ///   - action: The new playback behavior for the pin.
+  ///   - pinID: The identifier of the pin to update.
+  ///   - developerToken: The privileged developer token used to authorize the request.
+  ///
+  /// - Note: This endpoint requires a privileged developer token and access to private Apple Music APIs.
+  static func setPlaybackAction(
+    _ action: LibraryPinPlaybackAction,
+    forPinWithID pinID: String,
+    developerToken: String
+  ) async throws {
+    let request = try MusicLibraryPinMutationRequest(
+      pinID: pinID,
+      developerToken: developerToken,
+      mutation: .setPlaybackAction(action)
+    )
+    try await request.response()
+  }
+
   /// Private helper method that performs the actual pinning operation using an item ID.
   ///
   /// - Parameters:

--- a/Sources/MusanovaKit/Library/Pins/MusicLibraryPinMutationRequest.swift
+++ b/Sources/MusanovaKit/Library/Pins/MusicLibraryPinMutationRequest.swift
@@ -1,0 +1,81 @@
+//
+//  MusicLibraryPinMutationRequest.swift
+//  MusanovaKit
+//
+//  Created by Rudrank Riyam on 10/07/26.
+//
+
+import Foundation
+
+/// The playback behavior used when a library pin is selected.
+public enum LibraryPinPlaybackAction: String, Codable, Sendable {
+  /// Plays the pinned item in its natural order.
+  case play
+
+  /// Shuffles the contents of the pinned item.
+  case shuffle
+}
+
+enum MusicLibraryPinMutation: Sendable {
+  case move(afterPinID: String?)
+  case setPlaybackAction(LibraryPinPlaybackAction)
+
+  var method: HTTPMethod {
+    switch self {
+    case .move:
+      .post
+    case .setPlaybackAction:
+      .patch
+    }
+  }
+
+  var queryItem: URLQueryItem {
+    switch self {
+    case let .move(afterPinID):
+      URLQueryItem(name: "after", value: afterPinID ?? "top")
+    case let .setPlaybackAction(action):
+      URLQueryItem(name: "action", value: action.rawValue)
+    }
+  }
+}
+
+struct MusicLibraryPinMutationRequest {
+  let developerToken: String
+  let pinID: String
+  let mutation: MusicLibraryPinMutation
+
+  init(pinID: String, developerToken: String, mutation: MusicLibraryPinMutation) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+
+    self.pinID = pinID
+    self.developerToken = developerToken
+    self.mutation = mutation
+  }
+
+  var endpointURL: URL {
+    get throws {
+      var components = AppleMusicAMPURLComponents()
+      components.path = "me/library/pins/\(pinID)"
+      components.queryItems = [mutation.queryItem]
+
+      guard let url = components.url else {
+        throw MusanovaKitError.invalidURL(
+          description: "Failed to construct library pin mutation URL for pin: \(pinID)"
+        )
+      }
+
+      return url
+    }
+  }
+
+  func response() async throws {
+    let request = MusicPrivilegedDataRequest(
+      url: try endpointURL,
+      developerToken: developerToken,
+      method: mutation.method
+    )
+    _ = try await request.response()
+  }
+}

--- a/Tests/MusanovaKitTests/LibraryPinMetaTests.swift
+++ b/Tests/MusanovaKitTests/LibraryPinMetaTests.swift
@@ -43,6 +43,7 @@ struct LibraryPinMetaTests {
 
     let libraryPin = try #require(pin.libraryPin)
     #expect(libraryPin.action == "play")
+    #expect(libraryPin.actionKind == .play)
     #expect(libraryPin.positionUUID == "321069fb-bf1b-41ed-a239-0ae56fa7b35d")
   }
 
@@ -74,7 +75,33 @@ struct LibraryPinMetaTests {
 
     let libraryPin = try #require(pin.libraryPin)
     #expect(libraryPin.action == "drillIn")
+    #expect(libraryPin.actionKind == .drillIn)
     #expect(libraryPin.positionUUID == "DC6E1538-7515-4FF7-86D7-2CBF28790BDF")
+  }
+
+  @Test
+  func testUnknownLibraryPinActionRemainsAvailableAsRawValue() throws {
+    let jsonString = """
+    {
+      "id": "p.example",
+      "type": "library-playlists",
+      "attributes": {
+        "name": "Example"
+      },
+      "meta": {
+        "libraryPin": {
+          "action": "open",
+          "positionUUID": "D3FEED98-DC16-4C25-B96E-C73DA7247A43"
+        }
+      }
+    }
+    """
+
+    let data = try #require(jsonString.data(using: .utf8))
+    let pin = try JSONDecoder().decode(LibraryPin.self, from: data)
+
+    #expect(pin.libraryPin?.action == "open")
+    #expect(pin.libraryPin?.actionKind == nil)
   }
 
   @Test

--- a/Tests/MusanovaKitTests/LibraryPinMutationRequestTests.swift
+++ b/Tests/MusanovaKitTests/LibraryPinMutationRequestTests.swift
@@ -1,0 +1,75 @@
+//
+//  LibraryPinMutationRequestTests.swift
+//  MusanovaKitTests
+//
+//  Created by Rudrank Riyam on 10/07/26.
+//
+
+import Foundation
+import Testing
+
+@testable import MusanovaKit
+
+@Suite
+struct LibraryPinMutationRequestTests {
+  @Test
+  func movePinAfterAnotherPinUsesPostAndAfterQuery() throws {
+    let request = try MusicLibraryPinMutationRequest(
+      pinID: "p.moved",
+      developerToken: "test_token",
+      mutation: .move(afterPinID: "p.preceding")
+    )
+
+    #expect(request.mutation.method == .post)
+    try expectEndpoint(request.endpointURL, pinID: "p.moved", queryName: "after", value: "p.preceding")
+  }
+
+  @Test
+  func movePinToTopUsesTopSentinel() throws {
+    let request = try MusicLibraryPinMutationRequest(
+      pinID: "p.moved",
+      developerToken: "test_token",
+      mutation: .move(afterPinID: nil)
+    )
+
+    #expect(request.mutation.method == .post)
+    try expectEndpoint(request.endpointURL, pinID: "p.moved", queryName: "after", value: "top")
+  }
+
+  @Test(arguments: [LibraryPinPlaybackAction.play, .shuffle])
+  func setPlaybackActionUsesPatch(action: LibraryPinPlaybackAction) throws {
+    let request = try MusicLibraryPinMutationRequest(
+      pinID: "p.example",
+      developerToken: "test_token",
+      mutation: .setPlaybackAction(action)
+    )
+
+    #expect(request.mutation.method == .patch)
+    try expectEndpoint(request.endpointURL, pinID: "p.example", queryName: "action", value: action.rawValue)
+  }
+
+  @Test
+  func mutationRequiresDeveloperToken() {
+    #expect(throws: MusanovaKitError.self) {
+      try MusicLibraryPinMutationRequest(
+        pinID: "p.example",
+        developerToken: "",
+        mutation: .move(afterPinID: nil)
+      )
+    }
+  }
+
+  private func expectEndpoint(
+    _ url: URL,
+    pinID: String,
+    queryName: String,
+    value: String
+  ) throws {
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+    #expect(components.scheme == "https")
+    #expect(components.host == "amp-api.music.apple.com")
+    #expect(components.path == "/v1/me/library/pins/\(pinID)")
+    #expect(components.queryItems == [URLQueryItem(name: queryName, value: value)])
+  }
+}


### PR DESCRIPTION
## What changed

MusanovaKit can now reorder library pins and change a pin's default playback action.

- Move a pin after another pin, or move it to the top
- Set a pin's action to `play` or `shuffle`
- Read known pin actions through `LibraryPinActionKind` while keeping the existing raw string
- See the new calls in the README

The mutation request builder keeps the private endpoint details out of `MLibrary` and lets the tests check the HTTP method, path, and query without touching a real account.

## Checks

- `swift test` (59 tests passed)
- SwiftLint strict mode on all changed Swift files (0 violations)
- `git diff --check`

No live pin mutation ran during development or testing.