### PR TITLE
Add private Apple Music concerts APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ MusanovaKit lets you explore Apple Music features that are not exposed through t
 - [Authentication](#authentication)
   - [Privileged developer token](#privileged-developer-token)
   - [Music user token](#music-user-token)
+- [Concerts](#concerts)
+  - [Concert details](#concert-details)
+  - [Artist concerts](#artist-concerts)
 - [Lyrics](#lyrics)
   - [Fetching TTML lyrics](#fetching-ttml-lyrics)
   - [Working with timed segments](#working-with-timed-segments)
@@ -51,6 +54,64 @@ Obtain a privileged Apple Music developer token from your internal tooling and p
 ### Music user token
 
 When you call MusanovaKit from a signed-in MusicKit app, the system automatically attaches the Music User Token to privileged requests. If you issue requests from outside MusicKit (for example, using `curl`), include the `Media-User-Token` header manually.
+
+## Concerts
+
+Load Apple Music's concert hub by storefront. Filters support a geohash, calendar dates, genres, selected sections, and per-section limits.
+
+```swift
+let options = ConcertHubOptions(
+    geoHashLocation: "gcpvj",
+    dateRange: ConcertDateRange(
+        startDate: "2026-07-10",
+        endDate: "2026-07-31"
+    ),
+    genreIDs: ["14"]
+)
+
+let hub = try await MConcerts.hub(
+    storefront: "gb",
+    developerToken: token,
+    options: options
+)
+
+for section in hub.orderedContainers {
+    print(section.title ?? "Concerts")
+    section.data.forEach { print($0.attributes.name) }
+}
+```
+
+### Concert details
+
+The detail response includes venues, coordinates, postal addresses, artists, related playlists, ticket vendors, and the data providers behind the event.
+
+```swift
+let concert = try await MConcerts.concert(
+    id: "ce.example",
+    storefront: "gb",
+    developerToken: token
+)
+
+print(concert.attributes.name)
+print(concert.relationships?.venues?.data.first?.attributes.name ?? "No venue")
+```
+
+### Artist concerts
+
+An artist lookup returns the complete upcoming view. Pass a geohash to request Apple's nearby view in the same response.
+
+```swift
+let concerts = try await MConcerts.upcomingConcerts(
+    forArtistID: "1462541757",
+    storefront: "gb",
+    geoHashLocation: "gcpvj",
+    limit: 8,
+    developerToken: token
+)
+
+print(concerts.all.data.count)
+print(concerts.nearby?.data.count ?? 0)
+```
 
 ## Lyrics
 

--- a/Sources/MusanovaKit/Concerts/ArtistUpcomingConcerts.swift
+++ b/Sources/MusanovaKit/Concerts/ArtistUpcomingConcerts.swift
@@ -1,0 +1,34 @@
+//
+//  ArtistUpcomingConcerts.swift
+//  MusanovaKit
+//
+
+import Foundation
+
+/// Upcoming concert views returned for an Apple Music artist.
+public struct ArtistUpcomingConcerts: Codable, Hashable, Sendable {
+  public let artistID: String
+  public let artistName: String?
+  public let all: ConcertView
+  public let nearby: ConcertView?
+}
+
+struct ConcertArtistPageResponse: Decodable {
+  let data: [ConcertArtistPage]
+}
+
+struct ConcertArtistPage: Decodable {
+  let id: String
+  let attributes: ConcertArtistAttributes?
+  let views: ConcertArtistViews
+}
+
+struct ConcertArtistViews: Decodable {
+  let allUpcomingConcerts: ConcertView
+  let nearbyUpcomingConcerts: ConcertView?
+
+  enum CodingKeys: String, CodingKey {
+    case allUpcomingConcerts = "all-upcoming-concerts"
+    case nearbyUpcomingConcerts = "nearby-upcoming-concerts"
+  }
+}

--- a/Sources/MusanovaKit/Concerts/Concert.swift
+++ b/Sources/MusanovaKit/Concerts/Concert.swift
@@ -1,0 +1,156 @@
+//
+//  Concert.swift
+//  MusanovaKit
+//
+
+import Foundation
+
+/// A concert returned by Apple Music's private concerts API.
+public struct Concert: Codable, Hashable, Sendable {
+  public let id: String
+  public let type: String
+  public let href: String?
+  public let attributes: ConcertAttributes
+  public let relationships: ConcertRelationships?
+  public let views: ConcertViews?
+}
+
+/// Descriptive and ticketing information for a concert.
+public struct ConcertAttributes: Codable, Hashable, Sendable {
+  public let name: String
+  public let startISODateTime: String
+  public let endISODateTime: String?
+  public let timezone: String?
+  public let url: URL?
+  public let tickets: [ConcertTicket]?
+  public let eventDataProviders: [ConcertProvider]?
+}
+
+/// A source that supplies concert or ticket information.
+public struct ConcertProvider: Codable, Hashable, Sendable {
+  public let name: String
+  public let url: URL?
+}
+
+/// A link to buy a ticket from a named vendor.
+public struct ConcertTicket: Codable, Hashable, Sendable {
+  public let vendor: String?
+  public let url: URL
+  public let provider: ConcertProvider?
+}
+
+/// The resources related to a concert.
+public struct ConcertRelationships: Codable, Hashable, Sendable {
+  public let artists: ConcertRelationship<ConcertArtist>?
+  public let venues: ConcertRelationship<ConcertVenue>?
+  public let playlists: ConcertRelationship<ConcertPlaylist>?
+}
+
+/// A relationship in an Apple Music resource response.
+public struct ConcertRelationship<Resource: Codable & Hashable & Sendable>: Codable, Hashable, Sendable {
+  public let href: String?
+  public let data: [Resource]
+}
+
+/// An artist attached to a concert.
+public struct ConcertArtist: Codable, Hashable, Sendable {
+  public let id: String
+  public let type: String
+  public let href: String?
+  public let attributes: ConcertArtistAttributes
+}
+
+/// Artist fields returned with a concert.
+public struct ConcertArtistAttributes: Codable, Hashable, Sendable {
+  public let name: String
+  public let url: URL?
+  public let genreNames: [String]?
+  public let artwork: ConcertArtwork?
+}
+
+/// Artwork fields returned with concert artists and playlists.
+public struct ConcertArtwork: Codable, Hashable, Sendable {
+  public let url: String
+  public let width: Int?
+  public let height: Int?
+  public let bgColor: String?
+  public let textColor1: String?
+  public let textColor2: String?
+  public let textColor3: String?
+  public let textColor4: String?
+  public let hasP3: Bool?
+}
+
+/// A venue attached to a concert.
+public struct ConcertVenue: Codable, Hashable, Sendable {
+  public let id: String
+  public let type: String
+  public let href: String?
+  public let attributes: ConcertVenueAttributes
+}
+
+/// A venue's name, coordinates, and postal address.
+public struct ConcertVenueAttributes: Codable, Hashable, Sendable {
+  public let name: String
+  public let geoLocation: ConcertGeoLocation?
+  public let structuredAddress: ConcertAddress?
+}
+
+/// Geographic coordinates for a venue.
+public struct ConcertGeoLocation: Codable, Hashable, Sendable {
+  public let latitude: Double
+  public let longitude: Double
+}
+
+/// A postal address for a concert venue.
+public struct ConcertAddress: Codable, Hashable, Sendable {
+  public let address: String?
+  public let city: String?
+  public let region: String?
+  public let postCode: String?
+  public let country: String?
+  public let countryIsoCode: String?
+}
+
+/// A playlist attached to a concert, such as an artist's tour set list.
+public struct ConcertPlaylist: Codable, Hashable, Sendable {
+  public let id: String
+  public let type: String
+  public let href: String?
+  public let attributes: ConcertPlaylistAttributes
+}
+
+/// Playlist fields returned with a concert.
+public struct ConcertPlaylistAttributes: Codable, Hashable, Sendable {
+  public let name: String
+  public let curatorName: String?
+  public let url: URL?
+  public let artwork: ConcertArtwork?
+}
+
+/// Additional concert collections returned beside a concert detail response.
+public struct ConcertViews: Codable, Hashable, Sendable {
+  public let moreUpcomingConcerts: ConcertView?
+
+  enum CodingKeys: String, CodingKey {
+    case moreUpcomingConcerts = "more-upcoming-concerts"
+  }
+}
+
+/// A named view containing concerts.
+public struct ConcertView: Codable, Hashable, Sendable {
+  public let href: String?
+  public let attributes: ConcertViewAttributes?
+  public let data: [Concert]
+  public let meta: ConcertViewMeta?
+}
+
+/// Display fields for a concert view.
+public struct ConcertViewAttributes: Codable, Hashable, Sendable {
+  public let title: String?
+}
+
+/// Count metadata returned with some concert views.
+public struct ConcertViewMeta: Codable, Hashable, Sendable {
+  public let count: Int?
+}

--- a/Sources/MusanovaKit/Concerts/ConcertHub.swift
+++ b/Sources/MusanovaKit/Concerts/ConcertHub.swift
@@ -1,0 +1,85 @@
+//
+//  ConcertHub.swift
+//  MusanovaKit
+//
+
+import Foundation
+
+/// A section supported by Apple Music's concerts hub.
+public enum ConcertHubContainerKind: String, CaseIterable, Codable, Hashable, Sendable {
+  case thisWeek = "concerts-this-week"
+  case nextWeek = "concerts-next-week"
+  case popular = "popular-concerts"
+  case favoriteArtists = "favorite-artists-concerts"
+  case allUpcoming = "all-upcoming-concerts"
+  case moreUpcoming = "more-upcoming-concerts"
+}
+
+/// A calendar-date filter for the concerts hub.
+public struct ConcertDateRange: Codable, Hashable, Sendable {
+  /// The first date to include, formatted as `yyyy-MM-dd`.
+  public let startDate: String
+
+  /// The last date to include, formatted as `yyyy-MM-dd`.
+  public let endDate: String
+
+  public init(startDate: String, endDate: String) {
+    self.startDate = startDate
+    self.endDate = endDate
+  }
+}
+
+/// Options for loading the concerts hub.
+public struct ConcertHubOptions: Hashable, Sendable {
+  public var containers: [ConcertHubContainerKind]
+  public var geoHashLocation: String?
+  public var dateRange: ConcertDateRange?
+  public var genreIDs: [String]
+  public var limits: [ConcertHubContainerKind: Int]
+
+  public init(
+    containers: [ConcertHubContainerKind] = ConcertHubContainerKind.allCases,
+    geoHashLocation: String? = nil,
+    dateRange: ConcertDateRange? = nil,
+    genreIDs: [String] = [],
+    limits: [ConcertHubContainerKind: Int] = [.thisWeek: 12, .nextWeek: 12]
+  ) {
+    self.containers = containers
+    self.geoHashLocation = geoHashLocation
+    self.dateRange = dateRange
+    self.genreIDs = genreIDs
+    self.limits = limits
+  }
+}
+
+/// The ordered sections and concert resources in a concerts hub response.
+public struct ConcertHub: Codable, Hashable, Sendable {
+  public let containers: [String: ConcertHubContainer]
+  public let meta: ConcertHubMeta
+
+  /// Containers in the order supplied by Apple Music.
+  public var orderedContainers: [ConcertHubContainer] {
+    meta.containers.order.compactMap { containers[$0] }
+  }
+}
+
+/// A named section in the concerts hub.
+public struct ConcertHubContainer: Codable, Hashable, Sendable {
+  public let href: String?
+  public let title: String?
+  public let data: [Concert]
+}
+
+/// Metadata for the concerts hub.
+public struct ConcertHubMeta: Codable, Hashable, Sendable {
+  public let containers: ConcertHubContainerOrder
+}
+
+/// The server-selected order of hub container identifiers.
+public struct ConcertHubContainerOrder: Codable, Hashable, Sendable {
+  public let order: [String]
+}
+
+struct ConcertHubResponse: Decodable {
+  let results: ConcertHub
+}

--- a/Sources/MusanovaKit/Concerts/ConcertHubRequest.swift
+++ b/Sources/MusanovaKit/Concerts/ConcertHubRequest.swift
@@ -1,0 +1,211 @@
+//
+//  ConcertHubRequest.swift
+//  MusanovaKit
+//
+
+import Foundation
+
+struct ConcertHubRequest {
+  let storefront: String
+  let developerToken: String
+  var options: ConcertHubOptions
+
+  init(storefront: String, developerToken: String, options: ConcertHubOptions = ConcertHubOptions()) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+    self.storefront = storefront
+    self.developerToken = developerToken
+    self.options = options
+  }
+
+  var endpointURL: URL {
+    get throws {
+      var components = AppleMusicAMPURLComponents()
+      components.path = "concerts/\(storefront)/hub"
+
+      var queryItems = [
+        URLQueryItem(name: "containers", value: options.containers.map(\.rawValue).joined(separator: ",")),
+        URLQueryItem(name: "include[concerts]", value: "venues,artists"),
+        URLQueryItem(name: "omit[resource]", value: "autos"),
+        URLQueryItem(name: "art[artists:url]", value: "c"),
+        URLQueryItem(name: "extend", value: "editorialArtwork,hero")
+      ]
+
+      for container in options.containers {
+        if let limit = options.limits[container] {
+          queryItems.append(URLQueryItem(name: "limit[\(container.rawValue)]", value: String(limit)))
+        }
+      }
+      if let geoHashLocation = options.geoHashLocation, !geoHashLocation.isEmpty {
+        queryItems.append(URLQueryItem(name: "geoHashLocation", value: geoHashLocation))
+      }
+      if let dateRange = options.dateRange {
+        queryItems.append(URLQueryItem(
+          name: "filter[date]",
+          value: "\(dateRange.startDate)..\(dateRange.endDate)"
+        ))
+      }
+      if !options.genreIDs.isEmpty {
+        queryItems.append(URLQueryItem(name: "filter[genre]", value: options.genreIDs.joined(separator: ",")))
+      }
+      components.queryItems = queryItems
+
+      guard let url = components.url else {
+        throw MusanovaKitError.invalidURL(description: "Failed to construct concerts hub URL.")
+      }
+      return url
+    }
+  }
+
+  func response() async throws -> ConcertHub {
+    let data = try await concertData(from: endpointURL, developerToken: developerToken)
+    return try decode(ConcertHubResponse.self, from: data).results
+  }
+}
+
+struct ConcertDetailRequest {
+  let concertID: String
+  let storefront: String
+  let developerToken: String
+
+  init(concertID: String, storefront: String, developerToken: String) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+    self.concertID = concertID
+    self.storefront = storefront
+    self.developerToken = developerToken
+  }
+
+  var endpointURL: URL {
+    get throws {
+      var components = AppleMusicAMPURLComponents()
+      components.path = "catalog/\(storefront)/concerts/\(concertID)"
+      components.queryItems = [
+        URLQueryItem(name: "include[concerts]", value: "venues,artists,playlists"),
+        URLQueryItem(name: "fields[artists]", value: "artwork,name"),
+        URLQueryItem(name: "include[artists]", value: "default-playable-content"),
+        URLQueryItem(name: "extend[concerts]", value: "tickets,eventDataProviders,ticketDataProvider"),
+        URLQueryItem(name: "omit[resource]", value: "autos"),
+        URLQueryItem(name: "limit[more-upcoming-concerts]", value: "5"),
+        URLQueryItem(name: "views", value: "more-upcoming-concerts")
+      ]
+      guard let url = components.url else {
+        throw MusanovaKitError.invalidURL(description: "Failed to construct concert detail URL.")
+      }
+      return url
+    }
+  }
+
+  func response() async throws -> Concert {
+    let data = try await concertData(from: endpointURL, developerToken: developerToken)
+    let decoded = try decode(ConcertResponse.self, from: data)
+    guard let concert = decoded.data.first else {
+      throw MusanovaKitError.emptyResponse
+    }
+    return concert
+  }
+}
+
+struct ArtistConcertsRequest {
+  let artistID: String
+  let storefront: String
+  let geoHashLocation: String?
+  let limit: Int?
+  let developerToken: String
+
+  init(
+    artistID: String,
+    storefront: String,
+    geoHashLocation: String? = nil,
+    limit: Int? = nil,
+    developerToken: String
+  ) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+    self.artistID = artistID
+    self.storefront = storefront
+    self.geoHashLocation = geoHashLocation
+    self.limit = limit
+    self.developerToken = developerToken
+  }
+
+  var endpointURL: URL {
+    get throws {
+      var components = AppleMusicAMPURLComponents()
+      components.path = "catalog/\(storefront)/artists/\(artistID)"
+
+      var views = ["all-upcoming-concerts"]
+      var queryItems = [
+        URLQueryItem(name: "fields[artists]", value: "artwork,name"),
+        URLQueryItem(name: "include[concerts]", value: "venues")
+      ]
+      if let geoHashLocation, !geoHashLocation.isEmpty {
+        views.append("nearby-upcoming-concerts")
+        queryItems.append(URLQueryItem(name: "geoHashLocation", value: geoHashLocation))
+      }
+      if let limit {
+        queryItems.append(URLQueryItem(name: "limit[all-upcoming-concerts]", value: String(limit)))
+        if geoHashLocation?.isEmpty == false {
+          queryItems.append(URLQueryItem(name: "limit[nearby-upcoming-concerts]", value: String(limit)))
+        }
+      }
+      queryItems.append(URLQueryItem(name: "views", value: views.joined(separator: ",")))
+      components.queryItems = queryItems
+
+      guard let url = components.url else {
+        throw MusanovaKitError.invalidURL(description: "Failed to construct artist concerts URL.")
+      }
+      return url
+    }
+  }
+
+  func response() async throws -> ArtistUpcomingConcerts {
+    let data = try await concertData(from: endpointURL, developerToken: developerToken)
+    let decoded = try decode(ConcertArtistPageResponse.self, from: data)
+    guard let artist = decoded.data.first else {
+      throw MusanovaKitError.emptyResponse
+    }
+    return ArtistUpcomingConcerts(
+      artistID: artist.id,
+      artistName: artist.attributes?.name,
+      all: artist.views.allUpcomingConcerts,
+      nearby: artist.views.nearbyUpcomingConcerts
+    )
+  }
+}
+
+private struct ConcertResponse: Decodable {
+  let data: [Concert]
+}
+
+private func concertData(from url: URL, developerToken: String) async throws -> Data {
+  do {
+    let response = try await MusicPrivilegedDataRequest(
+      url: url,
+      developerToken: developerToken
+    ).response()
+    guard !response.data.isEmpty else {
+      throw MusanovaKitError.emptyResponse
+    }
+    return response.data
+  } catch let error as MusanovaKitError {
+    throw error
+  } catch let error as URLError {
+    throw MusanovaKitError.networkError(error.localizedDescription)
+  } catch {
+    throw MusanovaKitError.networkError(error.localizedDescription)
+  }
+}
+
+private func decode<Value: Decodable>(_ type: Value.Type, from data: Data) throws -> Value {
+  do {
+    return try JSONDecoder().decode(type, from: data)
+  } catch let error as DecodingError {
+    throw MusanovaKitError.decodingError(error.localizedDescription)
+  } catch {
+    throw MusanovaKitError.decodingError(error.localizedDescription)
+  }
+}

--- a/Sources/MusanovaKit/Concerts/MConcerts.swift
+++ b/Sources/MusanovaKit/Concerts/MConcerts.swift
@@ -1,0 +1,55 @@
+//
+//  MConcerts.swift
+//  MusanovaKit
+//
+
+import Foundation
+
+/// Access to Apple Music's private concerts API.
+public enum MConcerts {
+  /// Loads the concerts hub for a storefront.
+  public static func hub(
+    storefront: String,
+    developerToken: String,
+    options: ConcertHubOptions = ConcertHubOptions()
+  ) async throws -> ConcertHub {
+    let request = try ConcertHubRequest(
+      storefront: storefront,
+      developerToken: developerToken,
+      options: options
+    )
+    return try await request.response()
+  }
+
+  /// Loads one concert, including venues, artists, playlists, and ticket information.
+  public static func concert(
+    id: String,
+    storefront: String,
+    developerToken: String
+  ) async throws -> Concert {
+    let request = try ConcertDetailRequest(
+      concertID: id,
+      storefront: storefront,
+      developerToken: developerToken
+    )
+    return try await request.response()
+  }
+
+  /// Loads all upcoming concerts for an artist and, when supplied, a nearby view.
+  public static func upcomingConcerts(
+    forArtistID artistID: String,
+    storefront: String,
+    geoHashLocation: String? = nil,
+    limit: Int? = nil,
+    developerToken: String
+  ) async throws -> ArtistUpcomingConcerts {
+    let request = try ArtistConcertsRequest(
+      artistID: artistID,
+      storefront: storefront,
+      geoHashLocation: geoHashLocation,
+      limit: limit,
+      developerToken: developerToken
+    )
+    return try await request.response()
+  }
+}

--- a/Tests/MusanovaKitTests/Concerts/ConcertDecodingTests.swift
+++ b/Tests/MusanovaKitTests/Concerts/ConcertDecodingTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import MusanovaKit
+
+@Suite
+struct ConcertDecodingTests {
+  @Test
+  func decodesConcertDetail() throws {
+    let response = try decodeFixture(ConcertFixtureResponse.self, named: "concertDetail")
+    let concert = try #require(response.data.first)
+
+    #expect(concert.id == "ce.example")
+    #expect(concert.attributes.name == "Example Festival")
+    #expect(concert.attributes.tickets?.first?.vendor == "Example Tickets")
+    #expect(concert.attributes.eventDataProviders?.first?.name == "Example Provider")
+    #expect(concert.relationships?.venues?.data.first?.attributes.structuredAddress?.city == "London")
+    #expect(concert.relationships?.artists?.data.first?.attributes.name == "Example Artist")
+    #expect(concert.relationships?.playlists?.data.first?.attributes.name == "Example Set List")
+    #expect(concert.views?.moreUpcomingConcerts?.data.first?.id == "ce.next")
+  }
+
+  @Test
+  func decodesHubAndPreservesContainerOrder() throws {
+    let response = try decodeFixture(ConcertHubResponse.self, named: "concertHub")
+
+    #expect(response.results.meta.containers.order == ["popular-concerts", "concerts-this-week"])
+    #expect(response.results.orderedContainers.map(\.title) == ["Popular", "This Week"])
+    #expect(response.results.orderedContainers.first?.data.first?.id == "ce.popular")
+  }
+
+  @Test
+  func decodesArtistConcertViews() throws {
+    let response = try decodeFixture(ConcertArtistPageResponse.self, named: "artistConcerts")
+    let artist = try #require(response.data.first)
+
+    #expect(artist.attributes?.name == "Example Artist")
+    #expect(artist.views.allUpcomingConcerts.data.first?.id == "ce.anywhere")
+    #expect(artist.views.nearbyUpcomingConcerts?.data.first?.id == "ce.nearby")
+    #expect(artist.views.nearbyUpcomingConcerts?.meta?.count == 1)
+  }
+}
+
+private struct ConcertFixtureResponse: Decodable {
+  let data: [Concert]
+}
+
+private func decodeFixture<Value: Decodable>(_ type: Value.Type, named name: String) throws -> Value {
+  let url = try #require(Bundle.module.url(forResource: name, withExtension: "json"))
+  return try JSONDecoder().decode(type, from: Data(contentsOf: url))
+}

--- a/Tests/MusanovaKitTests/Concerts/ConcertRequestTests.swift
+++ b/Tests/MusanovaKitTests/Concerts/ConcertRequestTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import MusanovaKit
+
+@Suite
+struct ConcertRequestTests {
+  @Test
+  func hubURLIncludesFiltersAndLimits() throws {
+    let options = ConcertHubOptions(
+      containers: [.popular, .favoriteArtists],
+      geoHashLocation: "gcpvj",
+      dateRange: ConcertDateRange(startDate: "2026-07-10", endDate: "2026-07-31"),
+      genreIDs: ["14", "21"],
+      limits: [.popular: 6]
+    )
+    let request = try ConcertHubRequest(
+      storefront: "gb",
+      developerToken: "test-token",
+      options: options
+    )
+    let url = try request.endpointURL
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let queryItems = try #require(components.queryItems)
+    let query = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+    #expect(url.path == "/v1/concerts/gb/hub")
+    #expect(query["containers"] == "popular-concerts,favorite-artists-concerts")
+    #expect(query["include[concerts]"] == "venues,artists")
+    #expect(query["limit[popular-concerts]"] == "6")
+    #expect(query["geoHashLocation"] == "gcpvj")
+    #expect(query["filter[date]"] == "2026-07-10..2026-07-31")
+    #expect(query["filter[genre]"] == "14,21")
+  }
+
+  @Test
+  func detailURLRequestsTicketsAndRelationships() throws {
+    let request = try ConcertDetailRequest(
+      concertID: "ce.example",
+      storefront: "in",
+      developerToken: "test-token"
+    )
+    let url = try request.endpointURL
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let queryItems = try #require(components.queryItems)
+    let query = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+    #expect(url.path == "/v1/catalog/in/concerts/ce.example")
+    #expect(query["include[concerts]"] == "venues,artists,playlists")
+    #expect(query["extend[concerts]"] == "tickets,eventDataProviders,ticketDataProvider")
+    #expect(query["views"] == "more-upcoming-concerts")
+  }
+
+  @Test
+  func artistURLAddsNearbyViewOnlyWithLocation() throws {
+    let request = try ArtistConcertsRequest(
+      artistID: "1462541757",
+      storefront: "in",
+      geoHashLocation: "ttnfv",
+      limit: 8,
+      developerToken: "test-token"
+    )
+    let url = try request.endpointURL
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let queryItems = try #require(components.queryItems)
+    let query = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+    #expect(url.path == "/v1/catalog/in/artists/1462541757")
+    #expect(query["views"] == "all-upcoming-concerts,nearby-upcoming-concerts")
+    #expect(query["geoHashLocation"] == "ttnfv")
+    #expect(query["limit[all-upcoming-concerts]"] == "8")
+    #expect(query["limit[nearby-upcoming-concerts]"] == "8")
+  }
+
+  @Test
+  func missingTokenIsRejected() {
+    #expect(throws: MusanovaKitError.self) {
+      try ConcertDetailRequest(concertID: "ce.example", storefront: "us", developerToken: "")
+    }
+  }
+}

--- a/Tests/MusanovaKitTests/Resources/artistConcerts.json
+++ b/Tests/MusanovaKitTests/Resources/artistConcerts.json
@@ -1,0 +1,32 @@
+{
+  "data": [{
+    "id": "100",
+    "type": "artists",
+    "attributes": {"name": "Example Artist"},
+    "views": {
+      "all-upcoming-concerts": {
+        "attributes": {"title": "All Upcoming Concerts"},
+        "data": [{
+          "id": "ce.anywhere",
+          "type": "concerts",
+          "attributes": {
+            "name": "Anywhere Show",
+            "startISODateTime": "2026-07-11T18:00:00Z"
+          }
+        }]
+      },
+      "nearby-upcoming-concerts": {
+        "attributes": {"title": "Nearby Upcoming Concerts"},
+        "data": [{
+          "id": "ce.nearby",
+          "type": "concerts",
+          "attributes": {
+            "name": "Nearby Show",
+            "startISODateTime": "2026-07-12T18:00:00Z"
+          }
+        }],
+        "meta": {"count": 1}
+      }
+    }
+  }]
+}

--- a/Tests/MusanovaKitTests/Resources/concertDetail.json
+++ b/Tests/MusanovaKitTests/Resources/concertDetail.json
@@ -1,0 +1,81 @@
+{
+  "data": [{
+    "id": "ce.example",
+    "type": "concerts",
+    "href": "/v1/catalog/gb/concerts/ce.example",
+    "attributes": {
+      "name": "Example Festival",
+      "startISODateTime": "2026-07-25T18:00:00Z",
+      "endISODateTime": "2026-07-25T22:30:00Z",
+      "timezone": "Europe/London",
+      "url": "https://music.apple.com/gb/concerts/ce.example",
+      "eventDataProviders": [{
+        "name": "Example Provider",
+        "url": "https://provider.example/events/1"
+      }],
+      "tickets": [{
+        "vendor": "Example Tickets",
+        "url": "https://tickets.example/events/1",
+        "provider": {
+          "name": "Example Provider",
+          "url": "https://provider.example/events/1"
+        }
+      }]
+    },
+    "relationships": {
+      "artists": {
+        "data": [{
+          "id": "100",
+          "type": "artists",
+          "attributes": {
+            "name": "Example Artist",
+            "url": "https://music.apple.com/gb/artist/example/100",
+            "genreNames": ["Pop"]
+          }
+        }]
+      },
+      "venues": {
+        "data": [{
+          "id": "evu.example",
+          "type": "venues",
+          "attributes": {
+            "name": "Example Hall",
+            "geoLocation": {"latitude": 51.5, "longitude": -0.1},
+            "structuredAddress": {
+              "address": "1 Example Road",
+              "city": "London",
+              "region": "England",
+              "postCode": "E1 1AA",
+              "country": "United Kingdom",
+              "countryIsoCode": "GB"
+            }
+          }
+        }]
+      },
+      "playlists": {
+        "data": [{
+          "id": "pl.example",
+          "type": "playlists",
+          "attributes": {
+            "name": "Example Set List",
+            "curatorName": "Apple Music Pop",
+            "url": "https://music.apple.com/gb/playlist/pl.example"
+          }
+        }]
+      }
+    },
+    "views": {
+      "more-upcoming-concerts": {
+        "attributes": {"title": "More Upcoming Concerts"},
+        "data": [{
+          "id": "ce.next",
+          "type": "concerts",
+          "attributes": {
+            "name": "Next Show",
+            "startISODateTime": "2026-08-01T18:00:00Z"
+          }
+        }]
+      }
+    }
+  }]
+}

--- a/Tests/MusanovaKitTests/Resources/concertHub.json
+++ b/Tests/MusanovaKitTests/Resources/concertHub.json
@@ -1,0 +1,33 @@
+{
+  "results": {
+    "containers": {
+      "concerts-this-week": {
+        "title": "This Week",
+        "data": [{
+          "id": "ce.week",
+          "type": "concerts",
+          "attributes": {
+            "name": "Weekly Show",
+            "startISODateTime": "2026-07-11T18:00:00Z"
+          }
+        }]
+      },
+      "popular-concerts": {
+        "title": "Popular",
+        "data": [{
+          "id": "ce.popular",
+          "type": "concerts",
+          "attributes": {
+            "name": "Popular Show",
+            "startISODateTime": "2026-08-02T23:00:00Z"
+          }
+        }]
+      }
+    },
+    "meta": {
+      "containers": {
+        "order": ["popular-concerts", "concerts-this-week"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- Added `MConcerts` entry points for the concerts hub, concert details, and artist upcoming-concert views.
- Added typed concert, venue, address, artist, playlist, ticket, provider, hub, and view models.
- Added hub options for containers, geohash, date range, genre IDs, and per-container limits. Hub responses preserve Apple's container order.
- Documented the API and added URL-construction plus fixture-decoding tests. The fixtures contain invented IDs and domains; no account data or tokens are included.

## Why

Apple Music Web exposes concert data that the public MusicKit API doesn't currently model. These endpoints return dates, venues, coordinates, related artists and playlists, plus ticket links. MusanovaKit already wraps other private Apple Music endpoints, so this keeps the same token and request pattern.

## Validation

- `swift test` (61 tests passed)
- `swiftlint lint --strict` (0 violations)
- `git diff --check`

## Caveats

These are undocumented private endpoints and may change without notice. No live requests or account mutations were made while building this PR.