### PR TITLE
Add read-only taste preferences API

### DIFF
--- a/Sources/MusanovaKit/Taste Preferences/MTaste.swift
+++ b/Sources/MusanovaKit/Taste Preferences/MTaste.swift
@@ -1,0 +1,10 @@
+//
+//  MTaste.swift
+//  MusanovaKit
+//
+//  Created by Rudrank Riyam on 10/07/26.
+//
+
+/// A namespace for Apple Music taste-preference APIs.
+public struct MTaste {
+}

--- a/Sources/MusanovaKit/Taste Preferences/MusicTastePreferencesRequest.swift
+++ b/Sources/MusanovaKit/Taste Preferences/MusicTastePreferencesRequest.swift
@@ -1,0 +1,78 @@
+//
+//  MusicTastePreferencesRequest.swift
+//  MusanovaKit
+//
+//  Created by Rudrank Riyam on 10/07/26.
+//
+
+import Foundation
+
+public extension MTaste {
+  /// Fetches the taste preferences Apple Music uses to personalize recommendations.
+  ///
+  /// - Parameter developerToken: A privileged Apple Music developer token.
+  /// - Returns: The taste-preference resources for the current Apple Music user.
+  /// - Throws: An error if the request fails or its response cannot be decoded.
+  ///
+  /// - Note: This endpoint requires a privileged developer token and access to private Apple Music APIs.
+  static func preferences(developerToken: String) async throws -> TastePreferencesResponse {
+    let request = try MusicTastePreferencesRequest(developerToken: developerToken)
+    return try await request.response()
+  }
+}
+
+/// A request that fetches the current Apple Music user's taste preferences.
+public struct MusicTastePreferencesRequest {
+  private let developerToken: String
+
+  /// Creates a taste-preferences request.
+  ///
+  /// - Parameter developerToken: A privileged Apple Music developer token. Must not be empty.
+  /// - Throws: `MusanovaKitError.missingDeveloperToken` when the token is empty.
+  public init(developerToken: String) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+
+    self.developerToken = developerToken
+  }
+
+  /// Fetches and decodes the current user's taste preferences.
+  public func response() async throws -> TastePreferencesResponse {
+    do {
+      let request = MusicPrivilegedDataRequest(url: try tastePreferencesEndpointURL, developerToken: developerToken)
+      let response = try await request.response()
+
+      do {
+        return try JSONDecoder().decode(TastePreferencesResponse.self, from: response.data)
+      } catch let decodingError as DecodingError {
+        throw MusanovaKitError.decodingError(decodingError.localizedDescription)
+      } catch {
+        throw MusanovaKitError.decodingError(error.localizedDescription)
+      }
+    } catch let error as MusanovaKitError {
+      throw error
+    } catch let error as URLError {
+      throw MusanovaKitError.networkError(error.localizedDescription)
+    } catch {
+      throw MusanovaKitError.networkError(error.localizedDescription)
+    }
+  }
+}
+
+extension MusicTastePreferencesRequest {
+  var tastePreferencesEndpointURL: URL {
+    get throws {
+      var components = AppleMusicAMPURLComponents()
+      components.path = "me/taste/taste-preferences"
+
+      guard let url = components.url else {
+        throw MusanovaKitError.invalidURL(
+          description: "Failed to construct taste preferences URL with path: \(components.path)"
+        )
+      }
+
+      return url
+    }
+  }
+}

--- a/Sources/MusanovaKit/Taste Preferences/MusicTastePreferencesRequest.swift
+++ b/Sources/MusanovaKit/Taste Preferences/MusicTastePreferencesRequest.swift
@@ -11,13 +11,13 @@ public extension MTaste {
   /// Fetches the taste preferences Apple Music uses to personalize recommendations.
   ///
   /// - Parameter developerToken: A privileged Apple Music developer token.
-  /// - Returns: The taste-preference resources for the current Apple Music user.
+  /// - Returns: The resolved taste-preference resources for the current Apple Music user.
   /// - Throws: An error if the request fails or its response cannot be decoded.
   ///
   /// - Note: This endpoint requires a privileged developer token and access to private Apple Music APIs.
-  static func preferences(developerToken: String) async throws -> TastePreferencesResponse {
+  static func preferences(developerToken: String) async throws -> [TastePreference] {
     let request = try MusicTastePreferencesRequest(developerToken: developerToken)
-    return try await request.response()
+    return try await request.response().preferences
   }
 }
 

--- a/Sources/MusanovaKit/Taste Preferences/TastePreference.swift
+++ b/Sources/MusanovaKit/Taste Preferences/TastePreference.swift
@@ -17,6 +17,9 @@ public struct TastePreferenceReference: Decodable, Hashable, Identifiable, Senda
 
   /// The relative API URL for the resource, when supplied.
   public let href: String?
+
+  /// Expanded attributes when the endpoint returns resources inline.
+  public let attributes: TastePreference.Attributes?
 }
 
 /// A taste-preference resource returned for the current Apple Music user.
@@ -65,12 +68,20 @@ public struct TastePreferencesResponse: Decodable, Hashable, Sendable {
 
   /// Expanded preferences in the order supplied by `data`.
   public var preferences: [TastePreference] {
-    guard let tastePreferences = resources?.tastePreferences else {
-      return []
-    }
-
     return data.compactMap { reference in
-      tastePreferences[reference.id]
+      if let attributes = reference.attributes {
+        return TastePreference(
+          id: reference.id,
+          type: reference.type,
+          href: reference.href,
+          attributes: attributes
+        )
+      }
+
+      guard let tastePreferences = resources?.tastePreferences else {
+        return nil
+      }
+      return tastePreferences[reference.id]
         ?? tastePreferences.values.first { $0.id == reference.id }
     }
   }

--- a/Sources/MusanovaKit/Taste Preferences/TastePreference.swift
+++ b/Sources/MusanovaKit/Taste Preferences/TastePreference.swift
@@ -7,8 +7,20 @@
 
 import Foundation
 
+/// A resource identifier from the taste-preferences response.
+public struct TastePreferenceReference: Decodable, Hashable, Identifiable, Sendable {
+  /// The resource identifier.
+  public let id: String
+
+  /// The server-provided resource type.
+  public let type: String
+
+  /// The relative API URL for the resource, when supplied.
+  public let href: String?
+}
+
 /// A taste-preference resource returned for the current Apple Music user.
-public struct TastePreference: Codable, Hashable, Identifiable, Sendable {
+public struct TastePreference: Decodable, Hashable, Identifiable, Sendable {
   /// The resource identifier.
   public let id: String
 
@@ -20,37 +32,46 @@ public struct TastePreference: Codable, Hashable, Identifiable, Sendable {
 
   /// The preference's display name and value.
   public let attributes: Attributes
-
-  public init(id: String, type: String, href: String? = nil, attributes: Attributes) {
-    self.id = id
-    self.type = type
-    self.href = href
-    self.attributes = attributes
-  }
 }
 
 public extension TastePreference {
   /// Attributes for a taste-preference resource.
-  struct Attributes: Codable, Hashable, Sendable {
+  struct Attributes: Decodable, Hashable, Sendable {
     /// The display name of the genre or other preference.
     public let name: String
 
     /// The raw preference level returned by Apple Music.
     public let preference: Int
+  }
+}
 
-    public init(name: String, preference: Int) {
-      self.name = name
-      self.preference = preference
-    }
+/// Expanded resources returned alongside taste-preference references.
+public struct TastePreferenceResources: Decodable, Hashable, Sendable {
+  /// Taste preferences keyed by their resource-map identifier.
+  public let tastePreferences: [String: TastePreference]?
+
+  enum CodingKeys: String, CodingKey {
+    case tastePreferences = "taste-preferences"
   }
 }
 
 /// The response returned by the taste-preferences endpoint.
-public struct TastePreferencesResponse: Codable, Hashable, Sendable {
-  /// The current user's taste-preference resources.
-  public let data: [TastePreference]
+public struct TastePreferencesResponse: Decodable, Hashable, Sendable {
+  /// References that define the current user's preference order.
+  public let data: [TastePreferenceReference]
 
-  public init(data: [TastePreference]) {
-    self.data = data
+  /// Expanded taste-preference resources.
+  public let resources: TastePreferenceResources?
+
+  /// Expanded preferences in the order supplied by `data`.
+  public var preferences: [TastePreference] {
+    guard let tastePreferences = resources?.tastePreferences else {
+      return []
+    }
+
+    return data.compactMap { reference in
+      tastePreferences[reference.id]
+        ?? tastePreferences.values.first { $0.id == reference.id }
+    }
   }
 }

--- a/Sources/MusanovaKit/Taste Preferences/TastePreference.swift
+++ b/Sources/MusanovaKit/Taste Preferences/TastePreference.swift
@@ -1,0 +1,56 @@
+//
+//  TastePreference.swift
+//  MusanovaKit
+//
+//  Created by Rudrank Riyam on 10/07/26.
+//
+
+import Foundation
+
+/// A taste-preference resource returned for the current Apple Music user.
+public struct TastePreference: Codable, Hashable, Identifiable, Sendable {
+  /// The resource identifier.
+  public let id: String
+
+  /// The server-provided resource type.
+  public let type: String
+
+  /// The relative API URL for the resource, when supplied.
+  public let href: String?
+
+  /// The preference's display name and value.
+  public let attributes: Attributes
+
+  public init(id: String, type: String, href: String? = nil, attributes: Attributes) {
+    self.id = id
+    self.type = type
+    self.href = href
+    self.attributes = attributes
+  }
+}
+
+public extension TastePreference {
+  /// Attributes for a taste-preference resource.
+  struct Attributes: Codable, Hashable, Sendable {
+    /// The display name of the genre or other preference.
+    public let name: String
+
+    /// The raw preference level returned by Apple Music.
+    public let preference: Int
+
+    public init(name: String, preference: Int) {
+      self.name = name
+      self.preference = preference
+    }
+  }
+}
+
+/// The response returned by the taste-preferences endpoint.
+public struct TastePreferencesResponse: Codable, Hashable, Sendable {
+  /// The current user's taste-preference resources.
+  public let data: [TastePreference]
+
+  public init(data: [TastePreference]) {
+    self.data = data
+  }
+}

--- a/Tests/MusanovaKitTests/Resources/tastePreferences.json
+++ b/Tests/MusanovaKitTests/Resources/tastePreferences.json
@@ -1,0 +1,32 @@
+{
+  "data": [
+    {
+      "id": "ob.l-1",
+      "type": "taste-preferences",
+      "href": "/v1/me/taste/taste-preferences/ob.l-1",
+      "attributes": {
+        "name": "Alternative",
+        "preference": 1,
+        "futureAttribute": true
+      }
+    },
+    {
+      "id": "ob.l-2",
+      "type": "taste-preferences",
+      "href": "/v1/me/taste/taste-preferences/ob.l-2",
+      "attributes": {
+        "name": "Jazz",
+        "preference": 0
+      }
+    },
+    {
+      "id": "ob.l-3",
+      "type": "future-taste-preference-type",
+      "attributes": {
+        "name": "Future preference",
+        "preference": 2
+      }
+    }
+  ],
+  "futureTopLevelField": "ignored"
+}

--- a/Tests/MusanovaKitTests/Resources/tastePreferences.json
+++ b/Tests/MusanovaKitTests/Resources/tastePreferences.json
@@ -3,30 +3,54 @@
     {
       "id": "ob.l-1",
       "type": "taste-preferences",
-      "href": "/v1/me/taste/taste-preferences/ob.l-1",
-      "attributes": {
-        "name": "Alternative",
-        "preference": 1,
-        "futureAttribute": true
-      }
+      "href": "/v1/me/taste/taste-preferences/ob.l-1"
     },
     {
       "id": "ob.l-2",
       "type": "taste-preferences",
-      "href": "/v1/me/taste/taste-preferences/ob.l-2",
-      "attributes": {
-        "name": "Jazz",
-        "preference": 0
-      }
+      "href": "/v1/me/taste/taste-preferences/ob.l-2"
     },
     {
       "id": "ob.l-3",
-      "type": "future-taste-preference-type",
-      "attributes": {
-        "name": "Future preference",
-        "preference": 2
-      }
+      "type": "taste-preferences"
     }
   ],
+  "resources": {
+    "taste-preferences": {
+      "ob.l-1": {
+        "id": "ob.l-1",
+        "type": "taste-preferences",
+        "href": "/v1/me/taste/taste-preferences/ob.l-1",
+        "attributes": {
+          "name": "Alternative",
+          "preference": 1,
+          "futureAttribute": true
+        }
+      },
+      "ob.l-2": {
+        "id": "ob.l-2",
+        "type": "taste-preferences",
+        "href": "/v1/me/taste/taste-preferences/ob.l-2",
+        "attributes": {
+          "name": "Jazz",
+          "preference": 0
+        }
+      },
+      "opaque-map-key": {
+        "id": "ob.l-3",
+        "type": "future-taste-preference-type",
+        "attributes": {
+          "name": "Future preference",
+          "preference": 2
+        }
+      }
+    },
+    "future-resource-type": {
+      "future-id": {
+        "id": "future-id",
+        "type": "future-resource-type"
+      }
+    }
+  },
   "futureTopLevelField": "ignored"
 }

--- a/Tests/MusanovaKitTests/TastePreferencesTests.swift
+++ b/Tests/MusanovaKitTests/TastePreferencesTests.swift
@@ -50,6 +50,31 @@ struct TastePreferencesTests {
   }
 
   @Test
+  func responseDecodesExpandedResourcesWithoutResourceMap() throws {
+    let data = Data(
+      """
+      {
+        "data": [
+          {
+            "id": "ob.l-302539673",
+            "type": "taste-preferences",
+            "href": "/v1/me/taste/taste-preferences/ob.l-302539673",
+            "attributes": {"name": "Rock", "preference": 1}
+          }
+        ]
+      }
+      """.utf8
+    )
+
+    let response = try JSONDecoder().decode(TastePreferencesResponse.self, from: data)
+    let preference = try #require(response.preferences.first)
+
+    #expect(preference.id == "ob.l-302539673")
+    #expect(preference.attributes.name == "Rock")
+    #expect(preference.attributes.preference == 1)
+  }
+
+  @Test
   func responseWithoutExpandedResourcesResolvesToEmptyPreferences() throws {
     let data = Data(#"{"data":[{"id":"ob.l-1","type":"taste-preferences"}]}"#.utf8)
 

--- a/Tests/MusanovaKitTests/TastePreferencesTests.swift
+++ b/Tests/MusanovaKitTests/TastePreferencesTests.swift
@@ -34,16 +34,27 @@ struct TastePreferencesTests {
     let response = try JSONDecoder().decode(TastePreferencesResponse.self, from: data)
 
     #expect(response.data.count == 3)
+    #expect(response.data.map(\.id) == ["ob.l-1", "ob.l-2", "ob.l-3"])
+    #expect(response.preferences.count == 3)
 
-    let preferredGenre = try #require(response.data.first)
+    let preferredGenre = try #require(response.preferences.first)
     #expect(preferredGenre.id == "ob.l-1")
     #expect(preferredGenre.type == "taste-preferences")
     #expect(preferredGenre.href == "/v1/me/taste/taste-preferences/ob.l-1")
     #expect(preferredGenre.attributes.name == "Alternative")
     #expect(preferredGenre.attributes.preference == 1)
 
-    let preferenceWithoutHref = try #require(response.data.last)
+    let preferenceWithoutHref = try #require(response.preferences.last)
     #expect(preferenceWithoutHref.href == nil)
     #expect(preferenceWithoutHref.attributes.preference == 2)
+  }
+
+  @Test
+  func responseWithoutExpandedResourcesResolvesToEmptyPreferences() throws {
+    let data = Data(#"{"data":[{"id":"ob.l-1","type":"taste-preferences"}]}"#.utf8)
+
+    let response = try JSONDecoder().decode(TastePreferencesResponse.self, from: data)
+
+    #expect(response.preferences.isEmpty)
   }
 }

--- a/Tests/MusanovaKitTests/TastePreferencesTests.swift
+++ b/Tests/MusanovaKitTests/TastePreferencesTests.swift
@@ -1,0 +1,49 @@
+//
+//  TastePreferencesTests.swift
+//  MusanovaKitTests
+//
+//  Created by Rudrank Riyam on 10/07/26.
+//
+
+import Foundation
+import Testing
+
+@testable import MusanovaKit
+
+@Suite
+struct TastePreferencesTests {
+  @Test
+  func endpointURL() throws {
+    let request = try MusicTastePreferencesRequest(developerToken: "test_token")
+
+    #expect(try request.tastePreferencesEndpointURL == URL(string: "https://amp-api.music.apple.com/v1/me/taste/taste-preferences"))
+  }
+
+  @Test
+  func emptyDeveloperToken() {
+    #expect(throws: MusanovaKitError.self) {
+      _ = try MusicTastePreferencesRequest(developerToken: "")
+    }
+  }
+
+  @Test
+  func responseDecoding() throws {
+    let path = try #require(Bundle.module.path(forResource: "tastePreferences", ofType: "json"))
+    let data = try Data(contentsOf: URL(fileURLWithPath: path))
+
+    let response = try JSONDecoder().decode(TastePreferencesResponse.self, from: data)
+
+    #expect(response.data.count == 3)
+
+    let preferredGenre = try #require(response.data.first)
+    #expect(preferredGenre.id == "ob.l-1")
+    #expect(preferredGenre.type == "taste-preferences")
+    #expect(preferredGenre.href == "/v1/me/taste/taste-preferences/ob.l-1")
+    #expect(preferredGenre.attributes.name == "Alternative")
+    #expect(preferredGenre.attributes.preference == 1)
+
+    let preferenceWithoutHref = try #require(response.data.last)
+    #expect(preferenceWithoutHref.href == nil)
+    #expect(preferenceWithoutHref.attributes.preference == 2)
+  }
+}


### PR DESCRIPTION
## What changed

Adds a read-only API for `GET /v1/me/taste/taste-preferences` through `MTaste.preferences(developerToken:)`. The request uses the existing `MusicPrivilegedDataRequest`; this PR doesn't add a second request client or any write behavior.

The response matches Apple Music Web's payload: `data` contains ordered resource identifiers, and `resources["taste-preferences"]` contains the expanded objects. `MTaste.preferences` resolves those two pieces into `[TastePreference]` for callers. Raw resource types and numeric preference values stay open-ended so a new server value won't fail decoding.

## Why

Apple Music Web reads this private endpoint during taste onboarding. MusanovaKit can now fetch the same preference state without touching the POST endpoint that changes it.

## Checks

- `swift test` (58 tests passed)
- SwiftLint on all changed Swift files (0 violations)
- `git diff --check`