### PR TITLE
Add editorial room and multiroom APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ MusanovaKit lets you explore Apple Music features that are not exposed through t
 - [Library Pins](#library-pins)
   - [Fetching pinned items](#fetching-pinned-items)
   - [Custom pin requests](#custom-pin-requests)
+- [Editorial Rooms](#editorial-rooms)
 - [Disclaimer](#disclaimer)
 
 ## Requirements
@@ -227,6 +228,34 @@ Available configuration options:
 - `librarySongIncludes`: Relationships to include for songs
 - `libraryArtistIncludes`: Relationships to include for artists
 - `libraryMusicVideoIncludes`: Relationships to include for music videos
+
+## Editorial Rooms
+
+Apple Music uses rooms and multirooms to build editorial pages. A room holds catalog resources such as artists, albums, and playlists. A multiroom combines text sections, catalog content, links to child rooms, and hero artwork.
+
+```swift
+let room = try await MEditorial.room(
+    id: "room-id",
+    storefront: "us",
+    developerToken: token
+)
+
+for item in room.contents {
+    print("\(item.type): \(item.attributes?.name ?? item.id)")
+}
+
+let page = try await MEditorial.multiroom(
+    id: "multiroom-id",
+    storefront: "us",
+    developerToken: token
+)
+
+for section in page.children {
+    print(section.attributes?.title ?? section.id)
+}
+```
+
+`EditorialContentResource` keeps the resource `type`, identifier, and common display fields instead of assuming every item has the same catalog shape. Unknown resource types still decode, although their type-specific fields aren't modeled.
 
 ## Disclaimer
 

--- a/Sources/MusanovaKit/Editorial/EditorialRoom.swift
+++ b/Sources/MusanovaKit/Editorial/EditorialRoom.swift
@@ -1,5 +1,35 @@
 import Foundation
 
+/// Editorial copy that may arrive as plain text or as standard and short variants.
+public struct EditorialDescription: Codable, Sendable, Equatable {
+  public let standard: String?
+  public let short: String?
+
+  public init(from decoder: Decoder) throws {
+    let singleValue = try decoder.singleValueContainer()
+    if let value = try? singleValue.decode(String.self) {
+      standard = value
+      short = nil
+      return
+    }
+
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    standard = try values.decodeIfPresent(String.self, forKey: .standard)
+    short = try values.decodeIfPresent(String.self, forKey: .short)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var values = encoder.container(keyedBy: CodingKeys.self)
+    try values.encodeIfPresent(standard, forKey: .standard)
+    try values.encodeIfPresent(short, forKey: .short)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case standard
+    case short
+  }
+}
+
 /// A lightweight representation of artwork returned by editorial endpoints.
 public struct EditorialArtwork: Codable, Sendable, Equatable {
   public let url: String
@@ -37,7 +67,7 @@ public struct EditorialContentResource: Codable, Sendable, Equatable, Identifiab
     public let url: String?
     public let artwork: EditorialArtwork?
     public let genreNames: [String]?
-    public let description: String?
+    public let description: EditorialDescription?
   }
 }
 

--- a/Sources/MusanovaKit/Editorial/EditorialRoom.swift
+++ b/Sources/MusanovaKit/Editorial/EditorialRoom.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// A lightweight representation of artwork returned by editorial endpoints.
+public struct EditorialArtwork: Codable, Sendable, Equatable {
+  public let url: String
+  public let width: Int?
+  public let height: Int?
+  public let backgroundColor: String?
+  public let textColor1: String?
+  public let textColor2: String?
+  public let textColor3: String?
+  public let textColor4: String?
+  public let hasP3: Bool?
+
+  private enum CodingKeys: String, CodingKey {
+    case url, width, height, hasP3
+    case backgroundColor = "bgColor"
+    case textColor1, textColor2, textColor3, textColor4
+  }
+}
+
+/// A catalog resource embedded in an editorial room.
+///
+/// Editorial endpoints may mix artists, albums, playlists, songs, and other
+/// resource types. This model preserves their identity and common display
+/// attributes while ignoring type-specific fields that can change over time.
+public struct EditorialContentResource: Codable, Sendable, Equatable, Identifiable {
+  public let id: String
+  public let type: String
+  public let href: String?
+  public let attributes: Attributes?
+
+  public struct Attributes: Codable, Sendable, Equatable {
+    public let name: String?
+    public let title: String?
+    public let artistName: String?
+    public let url: String?
+    public let artwork: EditorialArtwork?
+    public let genreNames: [String]?
+    public let description: String?
+  }
+}
+
+/// A reference to another editorial room.
+public struct EditorialRoomReference: Codable, Sendable, Equatable, Identifiable {
+  public let id: String
+  public let type: String
+  public let href: String?
+}
+
+/// A text or content section embedded in an editorial multiroom.
+public struct EditorialElement: Codable, Sendable, Equatable, Identifiable {
+  public let id: String
+  public let type: String
+  public let attributes: Attributes?
+  public let relationships: Relationships?
+
+  public struct Attributes: Codable, Sendable, Equatable {
+    public let title: String?
+    public let description: String?
+    public let displayStyle: String?
+    public let lockupStyle: String?
+    public let editorialElementKind: String?
+    public let lastModifiedDate: String?
+  }
+
+  public struct Relationships: Codable, Sendable, Equatable {
+    public let contents: EditorialContentRelationship?
+    public let room: EditorialRoomRelationship?
+  }
+}
+
+/// A relationship containing mixed catalog resources.
+public struct EditorialContentRelationship: Codable, Sendable, Equatable {
+  public let href: String?
+  public let next: String?
+  public let data: [EditorialContentResource]
+}
+
+/// A relationship containing editorial room references.
+public struct EditorialRoomRelationship: Codable, Sendable, Equatable {
+  public let href: String?
+  public let data: [EditorialRoomReference]
+}
+
+/// A single editorial room and its content.
+public struct EditorialRoom: Codable, Sendable, Equatable, Identifiable {
+  public let id: String
+  public let type: String
+  public let href: String?
+  public let attributes: Attributes
+  public let relationships: Relationships?
+
+  public struct Attributes: Codable, Sendable, Equatable {
+    public let title: String?
+    public let defaultSort: String?
+    public let sorts: [String]?
+    public let resourceTypes: [String]?
+    public let editorialElementKind: String?
+    public let lastModifiedDate: String?
+    public let doNotFilter: Bool?
+  }
+
+  public struct Relationships: Codable, Sendable, Equatable {
+    public let contents: EditorialContentRelationship?
+  }
+
+  /// Catalog resources embedded directly in the room.
+  public var contents: [EditorialContentResource] {
+    relationships?.contents?.data ?? []
+  }
+}
+
+/// Hero presentation metadata for an editorial multiroom.
+public struct EditorialUber: Codable, Sendable, Equatable {
+  public let name: String?
+  public let description: String?
+  public let backgroundColor: String?
+  public let headerTextColor: String?
+  public let primaryTextColor: String?
+  public let titleTextColor: String?
+  public let heroArtwork: EditorialArtwork?
+
+  private enum CodingKeys: String, CodingKey {
+    case name, description, backgroundColor, headerTextColor, primaryTextColor, titleTextColor
+    case heroArtwork = "masterArt"
+  }
+}
+
+/// A multi-section editorial page.
+public struct EditorialMultiroom: Codable, Sendable, Equatable, Identifiable {
+  public let id: String
+  public let type: String
+  public let href: String?
+  public let attributes: Attributes
+  public let relationships: Relationships?
+
+  public struct Attributes: Codable, Sendable, Equatable {
+    public let lastModifiedDate: String?
+    public let uber: EditorialUber?
+  }
+
+  public struct Relationships: Codable, Sendable, Equatable {
+    public let children: EditorialChildrenRelationship?
+  }
+
+  /// Editorial sections embedded in the page.
+  public var children: [EditorialElement] {
+    relationships?.children?.data ?? []
+  }
+}
+
+/// A relationship containing the sections of a multiroom.
+public struct EditorialChildrenRelationship: Codable, Sendable, Equatable {
+  public let href: String?
+  public let next: String?
+  public let data: [EditorialElement]
+}

--- a/Sources/MusanovaKit/Editorial/MEditorial.swift
+++ b/Sources/MusanovaKit/Editorial/MEditorial.swift
@@ -1,0 +1,30 @@
+/// Entry points for Apple Music editorial rooms and multirooms.
+public enum MEditorial {
+  /// Fetches a room containing a collection of mixed catalog resources.
+  public static func room(
+    id: String,
+    storefront: String,
+    developerToken: String
+  ) async throws -> EditorialRoom {
+    let request = try MusicEditorialRoomRequest(
+      id: id,
+      storefront: storefront,
+      developerToken: developerToken
+    )
+    return try await request.response()
+  }
+
+  /// Fetches a multiroom containing editorial text, catalog content, and room references.
+  public static func multiroom(
+    id: String,
+    storefront: String,
+    developerToken: String
+  ) async throws -> EditorialMultiroom {
+    let request = try MusicEditorialMultiroomRequest(
+      id: id,
+      storefront: storefront,
+      developerToken: developerToken
+    )
+    return try await request.response()
+  }
+}

--- a/Sources/MusanovaKit/Editorial/MusicEditorialRoomRequest.swift
+++ b/Sources/MusanovaKit/Editorial/MusicEditorialRoomRequest.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+struct MusicEditorialRoomRequest {
+  private let id: String
+  private let storefront: String
+  private let developerToken: String
+
+  init(id: String, storefront: String, developerToken: String) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+    self.id = id
+    self.storefront = storefront
+    self.developerToken = developerToken
+  }
+
+  var endpointURL: URL {
+    get throws {
+      try editorialEndpointURL(storefront: storefront, resource: "rooms", id: id)
+    }
+  }
+
+  func response() async throws -> EditorialRoom {
+    try await fetchEditorialResource(
+      at: endpointURL,
+      developerToken: developerToken,
+      as: EditorialRoom.self
+    )
+  }
+}
+
+struct MusicEditorialMultiroomRequest {
+  private let id: String
+  private let storefront: String
+  private let developerToken: String
+
+  init(id: String, storefront: String, developerToken: String) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+    self.id = id
+    self.storefront = storefront
+    self.developerToken = developerToken
+  }
+
+  var endpointURL: URL {
+    get throws {
+      try editorialEndpointURL(storefront: storefront, resource: "multirooms", id: id)
+    }
+  }
+
+  func response() async throws -> EditorialMultiroom {
+    try await fetchEditorialResource(
+      at: endpointURL,
+      developerToken: developerToken,
+      as: EditorialMultiroom.self
+    )
+  }
+}
+
+private struct EditorialResourceResponse<Resource: Decodable>: Decodable {
+  let data: [Resource]
+}
+
+private func editorialEndpointURL(storefront: String, resource: String, id: String) throws -> URL {
+  var components = AppleMusicAMPURLComponents()
+  components.path = "editorial/\(storefront)/\(resource)/\(id)"
+
+  guard let url = components.url else {
+    throw MusanovaKitError.invalidURL(
+      description: "Failed to construct the \(resource) endpoint URL."
+    )
+  }
+  return url
+}
+
+private func fetchEditorialResource<Resource: Decodable>(
+  at url: URL,
+  developerToken: String,
+  as type: Resource.Type
+) async throws -> Resource {
+  do {
+    let request = MusicPrivilegedDataRequest(url: url, developerToken: developerToken)
+    let response = try await request.response()
+    guard !response.data.isEmpty else {
+      throw MusanovaKitError.emptyResponse
+    }
+
+    let decoded = try JSONDecoder().decode(
+      EditorialResourceResponse<Resource>.self,
+      from: response.data
+    )
+    guard let resource = decoded.data.first else {
+      throw MusanovaKitError.emptyResponse
+    }
+    return resource
+  } catch let error as MusanovaKitError {
+    throw error
+  } catch let error as DecodingError {
+    throw MusanovaKitError.decodingError(error.localizedDescription)
+  } catch let error as URLError {
+    throw MusanovaKitError.networkError(error.localizedDescription)
+  } catch {
+    throw MusanovaKitError.networkError(error.localizedDescription)
+  }
+}

--- a/Tests/MusanovaKitTests/EditorialTests.swift
+++ b/Tests/MusanovaKitTests/EditorialTests.swift
@@ -67,6 +67,10 @@ struct EditorialTests {
     #expect(multiroom.children.count == 2)
     #expect(multiroom.children[0].attributes?.title == "Start here")
     #expect(multiroom.children[1].relationships?.contents?.data.first?.type == "playlists")
+    #expect(
+      multiroom.children[1].relationships?.contents?.data.first?.attributes?.description?.short
+        == "A short description."
+    )
     #expect(multiroom.children[1].relationships?.room?.data.first?.id == "child-room")
   }
 }

--- a/Tests/MusanovaKitTests/EditorialTests.swift
+++ b/Tests/MusanovaKitTests/EditorialTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import MusanovaKit
+
+@Suite
+struct EditorialTests {
+  @Test
+  func roomURLUsesAMPEditorialEndpoint() throws {
+    let request = try MusicEditorialRoomRequest(
+      id: "room-id",
+      storefront: "gb",
+      developerToken: "token"
+    )
+
+    #expect(
+      try request.endpointURL.absoluteString
+        == "https://amp-api.music.apple.com/v1/editorial/gb/rooms/room-id"
+    )
+  }
+
+  @Test
+  func multiroomURLUsesAMPEditorialEndpoint() throws {
+    let request = try MusicEditorialMultiroomRequest(
+      id: "multiroom-id",
+      storefront: "us",
+      developerToken: "token"
+    )
+
+    #expect(
+      try request.endpointURL.absoluteString
+        == "https://amp-api.music.apple.com/v1/editorial/us/multirooms/multiroom-id"
+    )
+  }
+
+  @Test
+  func requestsRejectEmptyDeveloperToken() {
+    #expect(throws: MusanovaKitError.self) {
+      try MusicEditorialRoomRequest(id: "room-id", storefront: "us", developerToken: "")
+    }
+    #expect(throws: MusanovaKitError.self) {
+      try MusicEditorialMultiroomRequest(id: "multiroom-id", storefront: "us", developerToken: "")
+    }
+  }
+
+  @Test
+  func decodesRoomWithMixedCatalogResources() throws {
+    let response: TestResponse<EditorialRoom> = try decodeFixture(named: "editorialRoom")
+    let room = try #require(response.data.first)
+
+    #expect(room.id == "room-example")
+    #expect(room.attributes.title == "Featured Picks")
+    #expect(room.attributes.defaultSort == "featured")
+    #expect(room.contents.map(\.type) == ["artists", "albums", "future-resource"])
+    #expect(room.contents[0].attributes?.name == "Example Artist")
+    #expect(room.contents[1].attributes?.artistName == "Example Artist")
+    #expect(room.contents[2].attributes?.title == "Future content")
+  }
+
+  @Test
+  func decodesMultiroomHeroChildrenAndNestedContent() throws {
+    let response: TestResponse<EditorialMultiroom> = try decodeFixture(named: "editorialMultiroom")
+    let multiroom = try #require(response.data.first)
+
+    #expect(multiroom.attributes.uber?.backgroundColor == "101010")
+    #expect(multiroom.attributes.uber?.heroArtwork?.width == 2400)
+    #expect(multiroom.children.count == 2)
+    #expect(multiroom.children[0].attributes?.title == "Start here")
+    #expect(multiroom.children[1].relationships?.contents?.data.first?.type == "playlists")
+    #expect(multiroom.children[1].relationships?.room?.data.first?.id == "child-room")
+  }
+}
+
+private struct TestResponse<Resource: Decodable>: Decodable {
+  let data: [Resource]
+}
+
+private func decodeFixture<Resource: Decodable>(named name: String) throws -> TestResponse<Resource> {
+  let url = try #require(Bundle.module.url(forResource: name, withExtension: "json"))
+  return try JSONDecoder().decode(TestResponse<Resource>.self, from: Data(contentsOf: url))
+}

--- a/Tests/MusanovaKitTests/Resources/editorialMultiroom.json
+++ b/Tests/MusanovaKitTests/Resources/editorialMultiroom.json
@@ -43,7 +43,11 @@
                       "id": "playlist-example",
                       "type": "playlists",
                       "attributes": {
-                        "name": "Example Playlist"
+                        "name": "Example Playlist",
+                        "description": {
+                          "standard": "A longer playlist description.",
+                          "short": "A short description."
+                        }
                       }
                     }
                   ]

--- a/Tests/MusanovaKitTests/Resources/editorialMultiroom.json
+++ b/Tests/MusanovaKitTests/Resources/editorialMultiroom.json
@@ -1,0 +1,67 @@
+{
+  "data": [
+    {
+      "id": "multiroom-example",
+      "type": "multirooms",
+      "attributes": {
+        "lastModifiedDate": "2025-01-01T00:00:00Z",
+        "uber": {
+          "backgroundColor": "101010",
+          "headerTextColor": "ffffff",
+          "name": "Editorial Example",
+          "masterArt": {
+            "url": "https://example.invalid/{w}x{h}.jpg",
+            "width": 2400,
+            "height": 1080,
+            "bgColor": "101010"
+          }
+        }
+      },
+      "relationships": {
+        "children": {
+          "data": [
+            {
+              "id": "text-element",
+              "type": "editorial-elements",
+              "attributes": {
+                "title": "Start here",
+                "description": "A short editorial introduction.",
+                "displayStyle": "large",
+                "editorialElementKind": "404"
+              }
+            },
+            {
+              "id": "content-element",
+              "type": "editorial-elements",
+              "attributes": {
+                "lockupStyle": "Spotlight+ShortCopy"
+              },
+              "relationships": {
+                "contents": {
+                  "data": [
+                    {
+                      "id": "playlist-example",
+                      "type": "playlists",
+                      "attributes": {
+                        "name": "Example Playlist"
+                      }
+                    }
+                  ]
+                },
+                "room": {
+                  "data": [
+                    {
+                      "id": "child-room",
+                      "type": "rooms",
+                      "href": "/v1/editorial/zz/rooms/child-room"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Tests/MusanovaKitTests/Resources/editorialRoom.json
+++ b/Tests/MusanovaKitTests/Resources/editorialRoom.json
@@ -1,0 +1,55 @@
+{
+  "data": [
+    {
+      "id": "room-example",
+      "type": "rooms",
+      "href": "/v1/editorial/zz/rooms/room-example",
+      "attributes": {
+        "defaultSort": "featured",
+        "doNotFilter": false,
+        "editorialElementKind": "345",
+        "lastModifiedDate": "2025-01-01T00:00:00Z",
+        "resourceTypes": ["artists", "albums"],
+        "sorts": ["featured", "releaseDate"],
+        "title": "Featured Picks"
+      },
+      "relationships": {
+        "contents": {
+          "href": "/v1/editorial/zz/rooms/room-example/contents",
+          "data": [
+            {
+              "id": "artist-example",
+              "type": "artists",
+              "attributes": {
+                "name": "Example Artist",
+                "genreNames": ["Pop"],
+                "artwork": {
+                  "url": "https://example.invalid/{w}x{h}.jpg",
+                  "width": 1200,
+                  "height": 1200,
+                  "bgColor": "ffffff"
+                }
+              }
+            },
+            {
+              "id": "album-example",
+              "type": "albums",
+              "attributes": {
+                "name": "Example Album",
+                "artistName": "Example Artist"
+              }
+            },
+            {
+              "id": "future-example",
+              "type": "future-resource",
+              "attributes": {
+                "title": "Future content",
+                "newField": {"ignored": true}
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Adds read-only access to the private editorial room and multiroom endpoints through `MEditorial`. The models cover the fields needed to render these pages without trying to mirror every private response field.

- decodes room contents with mixed catalog resource types
- decodes multiroom hero artwork, editorial sections, nested contents, and room references
- ignores unknown catalog-specific fields so new resource types can still decode
- documents both public entry points in the README

Fixtures use fake storefronts, IDs, names, and image hosts. No live requests or account data are included.

## Checks

- `swift test` (59 tests)
- `swiftlint lint --strict Sources/MusanovaKit/Editorial Tests/MusanovaKitTests/EditorialTests.swift`
- `git diff --check`