### PR TITLE
Add Mescal-signed social relationship requests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,14 @@ let package = Package(
         .package(url: "https://github.com/rryam/MusadoraKit", from: "8.0.0"),
     ],
     targets: [
-        .target(name: "MusanovaKit", dependencies: ["MusadoraKit"]),
+        .target(
+            name: "MusanovaKit",
+            dependencies: ["MusadoraKit", "MusanovaKitPrivateSupport"]
+        ),
+        .target(
+            name: "MusanovaKitPrivateSupport",
+            publicHeadersPath: "include"
+        ),
         .testTarget(
             name: "MusanovaKitTests",
             dependencies: [

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ MusanovaKit lets you explore Apple Music features that are not exposed through t
   - [Pinning and unpinning items](#pinning-and-unpinning-items)
   - [Reordering pins and changing playback](#reordering-pins-and-changing-playback)
 - [Editorial Rooms](#editorial-rooms)
+- [Social Relationships](#social-relationships)
 - [Disclaimer](#disclaimer)
 
 ## Requirements
@@ -368,6 +369,28 @@ for section in page.children {
 ```
 
 `EditorialContentResource` keeps the resource `type`, identifier, and common display fields instead of assuming every item has the same catalog shape. Unknown resource types still decode, although their type-specific fields aren't modeled.
+
+## Social Relationships
+
+Apple Music protects follower, followee, and pending-follower reads with an action signature in addition to the developer and user tokens. MusanovaKit asks AppleMediaServices to add that signature before sending these requests.
+
+```swift
+let followers = try await MSocial.followers(developerToken: token)
+let followees = try await MSocial.followees(developerToken: token)
+let pending = try await MSocial.pendingFollowers(developerToken: token)
+```
+
+An account with no matching profiles returns an empty `profiles` array. For another endpoint that uses the same signature gate, opt in through `MusicPrivilegedDataRequest`:
+
+```swift
+let request = MusicPrivilegedDataRequest(
+    url: url,
+    developerToken: token,
+    requiresActionSignature: true
+)
+```
+
+This signer depends on a private system framework and can stop working after an OS update. Treat it as macOS research tooling, not production or App Store code.
 
 ## Disclaimer
 

--- a/Sources/MusanovaKit/MusanovaKitError.swift
+++ b/Sources/MusanovaKit/MusanovaKitError.swift
@@ -32,6 +32,9 @@ public enum MusanovaKitError: Error, Sendable {
 
   /// The country code could not be determined.
   case countryCodeUnavailable
+
+  /// Apple Music could not sign a request that requires Mescal authorization.
+  case requestSigningFailed(String)
 }
 
 extension MusanovaKitError: CustomStringConvertible {
@@ -60,6 +63,8 @@ extension MusanovaKitError: CustomStringConvertible {
       return "Developer token is missing or invalid. Please provide a valid developer token."
     case .countryCodeUnavailable:
       return "Unable to determine the current country code."
+    case let .requestSigningFailed(description):
+      return "Request signing failed: \(description)"
     }
   }
 }
@@ -87,6 +92,8 @@ extension MusanovaKitError: LocalizedError {
       return "Authentication failed due to missing or invalid developer token."
     case .countryCodeUnavailable:
       return "The country code is required but could not be determined."
+    case .requestSigningFailed:
+      return "Apple Music could not sign the privileged request."
     }
   }
 
@@ -108,6 +115,8 @@ extension MusanovaKitError: LocalizedError {
       return "Provide a valid developer token via the developerToken parameter or DEVELOPER_TOKEN environment variable."
     case .countryCodeUnavailable:
       return "Ensure you have proper network connectivity and MusicKit authorization."
+    case .requestSigningFailed:
+      return "Run the request on an Apple platform where AppleMediaServices action signing is available."
     }
   }
 }

--- a/Sources/MusanovaKit/Requests/MusicPrivilegedDataRequest.swift
+++ b/Sources/MusanovaKit/Requests/MusicPrivilegedDataRequest.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import MusadoraKit
+import MusanovaKitPrivateSupport
 
 /// HTTP methods supported for privileged data requests.
 public enum HTTPMethod: String, Sendable {
@@ -34,6 +35,9 @@ public struct MusicPrivilegedDataRequest: Sendable {
     /// The optional HTTP request body.
     private let body: Data?
 
+    /// Whether Apple Music's Mescal action signature is required.
+    private let requiresActionSignature: Bool
+
     /// Creates a data request with a URL request.
     ///
     /// - Parameters:
@@ -42,26 +46,45 @@ public struct MusicPrivilegedDataRequest: Sendable {
     ///   - method: The HTTP method for the request. Defaults to `.get`.
     ///   - headers: Additional HTTP headers for the request.
     ///   - body: An optional HTTP body, such as encoded JSON.
+    ///   - requiresActionSignature: Whether to add Apple's action signature before sending.
     public init(
         url: URL,
         developerToken: String,
         method: HTTPMethod = .get,
         headers: [String: String] = [:],
-        body: Data? = nil
+        body: Data? = nil,
+        requiresActionSignature: Bool = false
     ) {
         self.url = url
         self.developerToken = developerToken
         self.method = method
         self.headers = headers
         self.body = body
+        self.requiresActionSignature = requiresActionSignature
     }
 
     /// Fetches data from the Apple Music private API endpoint that the URL request defines.
     public func response() async throws -> MusicDataResponse {
-        let urlRequest = makeURLRequest()
+        var urlRequest = makeURLRequest()
+        if requiresActionSignature {
+            urlRequest = try signedActionRequest(urlRequest)
+        }
         let request = MusicDeveloperRequest(urlRequest: urlRequest, developerToken: developerToken)
 
         return try await request.response()
+    }
+
+    private func signedActionRequest(_ request: URLRequest) throws -> URLRequest {
+        guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            throw MusanovaKitError.requestSigningFailed("The URL request could not be copied for signing.")
+        }
+        var signingError: NSError?
+        guard MNKAddAppleMusicActionSignature(mutableRequest, &signingError) else {
+            throw MusanovaKitError.requestSigningFailed(
+                signingError?.localizedDescription ?? "Apple Music did not produce an action signature."
+            )
+        }
+        return mutableRequest as URLRequest
     }
 
     func makeURLRequest() -> URLRequest {

--- a/Sources/MusanovaKit/Social/MSocial.swift
+++ b/Sources/MusanovaKit/Social/MSocial.swift
@@ -16,4 +16,46 @@ public extension MSocial {
     let request = try MusicSocialProfileRequest(developerToken: developerToken)
     return try await request.response()
   }
+
+  /// Fetches people who follow the current user's Apple Music profile.
+  static func followers(
+    developerToken: String,
+    limit: Int = 20,
+    offset: Int = 0
+  ) async throws -> MusicSocialProfilesPage {
+    try await profiles(in: .followers, developerToken: developerToken, limit: limit, offset: offset)
+  }
+
+  /// Fetches people whom the current user follows on Apple Music.
+  static func followees(
+    developerToken: String,
+    limit: Int = 20,
+    offset: Int = 0
+  ) async throws -> MusicSocialProfilesPage {
+    try await profiles(in: .followees, developerToken: developerToken, limit: limit, offset: offset)
+  }
+
+  /// Fetches follow requests awaiting the current user's approval.
+  static func pendingFollowers(
+    developerToken: String,
+    limit: Int = 20,
+    offset: Int = 0
+  ) async throws -> MusicSocialProfilesPage {
+    try await profiles(in: .pendingFollowers, developerToken: developerToken, limit: limit, offset: offset)
+  }
+
+  private static func profiles(
+    in relationship: MusicSocialProfileRelationship,
+    developerToken: String,
+    limit: Int,
+    offset: Int
+  ) async throws -> MusicSocialProfilesPage {
+    var request = try MusicSocialProfilesRequest(
+      relationship: relationship,
+      developerToken: developerToken
+    )
+    request.limit = limit
+    request.offset = offset
+    return try await request.response()
+  }
 }

--- a/Sources/MusanovaKit/Social/MusicSocialProfileRelationship.swift
+++ b/Sources/MusanovaKit/Social/MusicSocialProfileRelationship.swift
@@ -1,0 +1,11 @@
+//
+//  MusicSocialProfileRelationship.swift
+//  MusanovaKit
+//
+
+/// A signed relationship on the current user's Apple Music social profile.
+public enum MusicSocialProfileRelationship: String, CaseIterable, Sendable {
+  case followers
+  case followees
+  case pendingFollowers = "pending-followers"
+}

--- a/Sources/MusanovaKit/Social/MusicSocialProfilesPage.swift
+++ b/Sources/MusanovaKit/Social/MusicSocialProfilesPage.swift
@@ -1,0 +1,22 @@
+//
+//  MusicSocialProfilesPage.swift
+//  MusanovaKit
+//
+
+/// A page of Apple Music social profiles.
+public struct MusicSocialProfilesPage: Decodable, Sendable {
+  public let profiles: [MusicSocialProfile]
+  public let href: String?
+  public let next: String?
+
+  public init(from decoder: Decoder) throws {
+    let response = try MusicSocialResponseBody(from: decoder)
+    self = response.profilePage()
+  }
+
+  init(profiles: [MusicSocialProfile], href: String? = nil, next: String? = nil) {
+    self.profiles = profiles
+    self.href = href
+    self.next = next
+  }
+}

--- a/Sources/MusanovaKit/Social/MusicSocialProfilesRequest.swift
+++ b/Sources/MusanovaKit/Social/MusicSocialProfilesRequest.swift
@@ -1,0 +1,85 @@
+//
+//  MusicSocialProfilesRequest.swift
+//  MusanovaKit
+//
+
+import Foundation
+import MusicKit
+
+/// A signed request for one relationship on the current user's Apple Music social profile.
+public struct MusicSocialProfilesRequest: Sendable {
+  public let relationship: MusicSocialProfileRelationship
+
+  private let developerToken: String
+
+  public var limit = 20
+  public var offset = 0
+  public var includeArtworkURLs = true
+
+  /// Creates a social relationship request.
+  public init(
+    relationship: MusicSocialProfileRelationship,
+    developerToken: String
+  ) throws {
+    guard !developerToken.isEmpty else {
+      throw MusanovaKitError.missingDeveloperToken
+    }
+    self.relationship = relationship
+    self.developerToken = developerToken
+  }
+
+  /// Fetches and decodes a page of Apple Music social profiles.
+  public func response() async throws -> MusicSocialProfilesPage {
+    do {
+      let request = MusicPrivilegedDataRequest(
+        url: try socialProfilesEndpointURL,
+        developerToken: developerToken,
+        requiresActionSignature: true
+      )
+      let response = try await request.response()
+
+      do {
+        return try JSONDecoder().decode(MusicSocialProfilesPage.self, from: response.data)
+      } catch let error as DecodingError {
+        throw MusanovaKitError.decodingError(error.localizedDescription)
+      } catch {
+        throw MusanovaKitError.decodingError(error.localizedDescription)
+      }
+    } catch let error as MusicDataRequest.Error where error.status == 404 && error.code == 40_403 {
+      return MusicSocialProfilesPage(profiles: [])
+    } catch let error as MusanovaKitError {
+      throw error
+    } catch let error as URLError {
+      throw MusanovaKitError.networkError(error.localizedDescription)
+    } catch {
+      throw MusanovaKitError.networkError(error.localizedDescription)
+    }
+  }
+}
+
+extension MusicSocialProfilesRequest {
+  var socialProfilesEndpointURL: URL {
+    get throws {
+      var components = AppleMusicAMPURLComponents()
+      components.path = "me/social/profile/\(relationship.rawValue)"
+
+      var queryItems = [
+        URLQueryItem(name: "limit", value: String(limit)),
+        URLQueryItem(name: "offset", value: String(offset)),
+        URLQueryItem(name: "extend", value: "followState"),
+        URLQueryItem(name: "format[resources]", value: "map")
+      ]
+      if includeArtworkURLs {
+        queryItems.append(URLQueryItem(name: "art[url]", value: "f"))
+      }
+      components.queryItems = queryItems
+
+      guard let url = components.url else {
+        throw MusanovaKitError.invalidURL(
+          description: "Failed to construct social relationship endpoint URL with path: \(components.path)"
+        )
+      }
+      return url
+    }
+  }
+}

--- a/Sources/MusanovaKit/Social/MusicSocialResponseBody.swift
+++ b/Sources/MusanovaKit/Social/MusicSocialResponseBody.swift
@@ -8,6 +8,16 @@ import Foundation
 struct MusicSocialResponseBody: Decodable, Sendable {
   let data: [MusicSocialResource]
   let resources: MusicSocialResourceMap?
+  let href: String?
+  let next: String?
+
+  func profilePage() -> MusicSocialProfilesPage {
+    MusicSocialProfilesPage(
+      profiles: data.map { profile(for: $0) },
+      href: href,
+      next: next
+    )
+  }
 
   func personalProfile() throws -> PersonalMusicSocialProfile {
     guard let identifier = data.first else {

--- a/Sources/MusanovaKitPrivateSupport/AppleMusicActionSigner.m
+++ b/Sources/MusanovaKitPrivateSupport/AppleMusicActionSigner.m
@@ -1,0 +1,64 @@
+#import "MusanovaKitPrivateSupport.h"
+
+#import <dlfcn.h>
+#import <objc/message.h>
+
+static NSString * const MNKActionSignerErrorDomain = @"MusanovaKit.ActionSigner";
+
+static BOOL MNKFail(NSError **error, NSInteger code, NSString *description) {
+    if (error) {
+        *error = [NSError errorWithDomain:MNKActionSignerErrorDomain
+                                     code:code
+                                 userInfo:@{NSLocalizedDescriptionKey: description}];
+    }
+    return NO;
+}
+
+BOOL MNKAddAppleMusicActionSignature(NSMutableURLRequest *request, NSError **error) {
+    void *handle = dlopen(
+        "/System/Library/PrivateFrameworks/AppleMediaServices.framework/AppleMediaServices",
+        RTLD_LAZY | RTLD_LOCAL
+    );
+    if (!handle) {
+        return MNKFail(error, 1, @"AppleMediaServices is unavailable on this system.");
+    }
+
+    Class mescalClass = NSClassFromString(@"AMSMescal");
+    Class decorationClass = NSClassFromString(@"AMSURLRequestDecoration");
+    SEL createBagSelector = NSSelectorFromString(@"createBagForSubProfile");
+    SEL decorateSelector = NSSelectorFromString(@"addMescalHeaderToRequest:type:bag:logKey:");
+
+    if (!mescalClass || !decorationClass ||
+        ![mescalClass respondsToSelector:createBagSelector] ||
+        ![decorationClass respondsToSelector:decorateSelector]) {
+        return MNKFail(error, 2, @"Apple Music action signing is unavailable on this system.");
+    }
+
+    id (*sendNoArguments)(id, SEL) = (void *)objc_msgSend;
+    id bag = sendNoArguments(mescalClass, createBagSelector);
+    if (!bag) {
+        return MNKFail(error, 3, @"Apple Music action signing could not load its configuration.");
+    }
+
+    id (*decorate)(id, SEL, id, NSInteger, id, id) = (void *)objc_msgSend;
+    id promise = decorate(
+        decorationClass,
+        decorateSelector,
+        request,
+        1,
+        bag,
+        @"MusanovaKit"
+    );
+
+    SEL waitSelector = NSSelectorFromString(@"waitUntilFinishedWithTimeout:");
+    if (promise && [promise respondsToSelector:waitSelector]) {
+        void (*wait)(id, SEL, NSTimeInterval) = (void *)objc_msgSend;
+        wait(promise, waitSelector, 30);
+    }
+
+    if (![request valueForHTTPHeaderField:@"X-Apple-ActionSignature"].length) {
+        return MNKFail(error, 4, @"Apple Music did not produce an action signature.");
+    }
+
+    return YES;
+}

--- a/Sources/MusanovaKitPrivateSupport/include/MusanovaKitPrivateSupport.h
+++ b/Sources/MusanovaKitPrivateSupport/include/MusanovaKitPrivateSupport.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Adds Apple's Mescal action signature to a mutable Apple Music request.
+FOUNDATION_EXPORT BOOL MNKAddAppleMusicActionSignature(
+    NSMutableURLRequest *request,
+    NSError * _Nullable * _Nullable error
+);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/MusanovaKitTests/Resources/socialProfiles.json
+++ b/Tests/MusanovaKitTests/Resources/socialProfiles.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    { "id": "social.one", "type": "social-profiles" },
+    { "id": "social.two", "type": "social-profiles" }
+  ],
+  "next": "/v1/me/social/profile/followees?offset=2&limit=2",
+  "resources": {
+    "social-profiles": {
+      "social.one": {
+        "id": "social.one",
+        "type": "social-profiles",
+        "href": "/v1/social/us/social-profiles/social.one",
+        "attributes": {
+          "name": "Morgan",
+          "handle": "morgan",
+          "isPrivate": false,
+          "isVerified": true,
+          "followState": "following"
+        }
+      },
+      "social.two": {
+        "id": "social.two",
+        "type": "social-profiles",
+        "href": "/v1/social/us/social-profiles/social.two",
+        "attributes": {
+          "name": "Taylor",
+          "handle": "taylor",
+          "isPrivate": true,
+          "isVerified": false,
+          "followState": "requested"
+        }
+      }
+    }
+  }
+}

--- a/Tests/MusanovaKitTests/Social/MusicSocialProfilesRequestTests.swift
+++ b/Tests/MusanovaKitTests/Social/MusicSocialProfilesRequestTests.swift
@@ -1,0 +1,54 @@
+//
+//  MusicSocialProfilesRequestTests.swift
+//  MusanovaKitTests
+//
+
+import Foundation
+import Testing
+
+@testable import MusanovaKit
+
+@Suite
+struct MusicSocialProfilesRequestTests {
+  @Test(arguments: MusicSocialProfileRelationship.allCases)
+  func constructsRelationshipEndpoint(_ relationship: MusicSocialProfileRelationship) throws {
+    var request = try MusicSocialProfilesRequest(
+      relationship: relationship,
+      developerToken: "test_token"
+    )
+    request.limit = 40
+    request.offset = 20
+
+    let endpointURL = try request.socialProfilesEndpointURL
+    let components = try #require(URLComponents(url: endpointURL, resolvingAgainstBaseURL: false))
+    let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+
+    #expect(endpointURL.path == "/v1/me/social/profile/\(relationship.rawValue)")
+    #expect(query["limit"] == "40")
+    #expect(query["offset"] == "20")
+    #expect(query["extend"] == "followState")
+    #expect(query["format[resources]"] == "map")
+    #expect(query["art[url]"] == "f")
+  }
+
+  @Test
+  func decodesPaginatedProfilesFromResourceMap() throws {
+    let url = try #require(Bundle.module.url(forResource: "socialProfiles", withExtension: "json"))
+    let data = try Data(contentsOf: url)
+    let page = try JSONDecoder().decode(MusicSocialProfilesPage.self, from: data)
+
+    #expect(page.profiles.count == 2)
+    #expect(page.profiles[0].id == "social.one")
+    #expect(page.profiles[0].attributes?.name == "Morgan")
+    #expect(page.profiles[0].attributes?.followState == .following)
+    #expect(page.profiles[1].attributes?.followState == .requested)
+    #expect(page.next == "/v1/me/social/profile/followees?offset=2&limit=2")
+  }
+
+  @Test
+  func rejectsMissingDeveloperToken() {
+    #expect(throws: MusanovaKitError.self) {
+      try MusicSocialProfilesRequest(relationship: .followers, developerToken: "")
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- add an opt-in `requiresActionSignature` path to `MusicPrivilegedDataRequest`
- load AppleMediaServices at runtime and ask its Mescal signer for `X-Apple-ActionSignature`
- restore followers, followees, and pending-followers as signed read APIs
- translate Apple Music's `40403 No related resources` response into an empty page

## Why

A fresh privileged web JWT still returned `40013 Invalid Request Signature` for the three relationship endpoints while the base profile returned 200. The native Music bag marks these actions as signed, and a Mescal-signed replay passed that gate.

## Live audit

- signed profile: 200 with one profile resource
- signed followers: request accepted; 40403 because this account has no followers
- signed followees: request accepted; 40403 because this account has no followees
- signed pending followers: request accepted; 40403 because this account has no pending requests
- the signer also works without manually supplying DSID or request timestamp

No token, DSID, or generated signature is stored in the branch.

## Verification

- 90 Swift tests pass
- strict SwiftLint passes for the changed Swift code
- the Objective-C bridge was compiled without linking AppleMediaServices and produced the expected signature header at runtime