### PR TITLE
Handle Replay playlists without curator handles

### DIFF
--- a/Sources/MusanovaKit/Music Summary/Search/MusicSummarySearchRequest.swift
+++ b/Sources/MusanovaKit/Music Summary/Search/MusicSummarySearchRequest.swift
@@ -84,8 +84,13 @@ struct MusicSummarySearchRequest {
 
       do {
         return try JSONDecoder().decode(MusicSummarySearches.self, from: response.data)
-      } catch let decodingError as DecodingError {
-        throw MusanovaKitError.decodingError(decodingError.localizedDescription)
+      } catch is DecodingError {
+        do {
+          let normalizedData = try ReplayPlaylistResponseNormalizer.normalize(response.data)
+          return try JSONDecoder().decode(MusicSummarySearches.self, from: normalizedData)
+        } catch let decodingError as DecodingError {
+          throw MusanovaKitError.decodingError(decodingError.localizedDescription)
+        }
       } catch {
         throw MusanovaKitError.decodingError(error.localizedDescription)
       }

--- a/Sources/MusanovaKit/Music Summary/Search/ReplayPlaylistResponseNormalizer.swift
+++ b/Sources/MusanovaKit/Music Summary/Search/ReplayPlaylistResponseNormalizer.swift
@@ -1,0 +1,37 @@
+//
+//  ReplayPlaylistResponseNormalizer.swift
+//  MusanovaKit
+//
+
+import Foundation
+
+enum ReplayPlaylistResponseNormalizer {
+  static func normalize(_ data: Data) throws -> Data {
+    let object = try JSONSerialization.jsonObject(with: data)
+    let normalizedObject = normalize(object)
+    return try JSONSerialization.data(withJSONObject: normalizedObject)
+  }
+
+  private static func normalize(_ value: Any) -> Any {
+    if let values = value as? [Any] {
+      return values.map(normalize)
+    }
+
+    guard var dictionary = value as? [String: Any] else {
+      return value
+    }
+
+    for (key, nestedValue) in dictionary {
+      dictionary[key] = normalize(nestedValue)
+    }
+
+    if dictionary["type"] as? String == "playlists",
+       var attributes = dictionary["attributes"] as? [String: Any],
+       attributes["curatorSocialHandle"] == nil {
+      attributes["curatorSocialHandle"] = ""
+      dictionary["attributes"] = attributes
+    }
+
+    return dictionary
+  }
+}

--- a/Tests/MusanovaKitTests/MusicSummariesSearchTests.swift
+++ b/Tests/MusanovaKitTests/MusicSummariesSearchTests.swift
@@ -61,4 +61,35 @@ struct MusicSummariesSearchTests {
     #expect(playlist.id == "pl.rp-bppRCjG6wWzB")
     #expect(playlist.name == "Replay 2016")
   }
+
+  @Test
+  func decodesReplayPlaylistWithoutCuratorSocialHandle() throws {
+    let path = try #require(Bundle.module.path(forResource: "musicSummariesSearch", ofType: "json"))
+    let fixtureData = try Data(contentsOf: URL(fileURLWithPath: path))
+    let fixture = try #require(JSONSerialization.jsonObject(with: fixtureData) as? [String: Any])
+    var data = try #require(fixture["data"] as? [[String: Any]])
+    var summary = try #require(data.first)
+    var relationships = try #require(summary["relationships"] as? [String: Any])
+    var playlistRelationship = try #require(relationships["playlist"] as? [String: Any])
+    var playlists = try #require(playlistRelationship["data"] as? [[String: Any]])
+    var playlist = try #require(playlists.first)
+    var attributes = try #require(playlist["attributes"] as? [String: Any])
+
+    attributes.removeValue(forKey: "curatorSocialHandle")
+    playlist["attributes"] = attributes
+    playlists[0] = playlist
+    playlistRelationship["data"] = playlists
+    relationships["playlist"] = playlistRelationship
+    summary["relationships"] = relationships
+    data[0] = summary
+
+    var liveResponse = fixture
+    liveResponse["data"] = data
+    let liveData = try JSONSerialization.data(withJSONObject: liveResponse)
+    let normalizedData = try ReplayPlaylistResponseNormalizer.normalize(liveData)
+    let summaries = try JSONDecoder().decode(MusicSummarySearches.self, from: normalizedData)
+
+    #expect(summaries.first?.year == 2016)
+    #expect(summaries.first?.playlist.name == "Replay 2016")
+  }
 }


### PR DESCRIPTION
## What changed

Apple Music no longer includes `curatorSocialHandle` on live Replay playlist resources, but MusicKit's `Playlist` decoder still expects the field. The Replay search path now retries decoding after adding an empty compatibility value to playlist resources that omit it.

The fallback is scoped to playlist resources and only runs after the original decode fails.

## Live evidence

- Replay search returned 200 with 4,272 bytes
- the first resource was `year-2026` with an inline Replay playlist
- its attributes had no `curatorSocialHandle`
- the existing fixture includes that field, which is why the old tests did not catch the live failure

## Verification

- added a regression test that removes the field from the fixture
- 91 tests pass
- strict SwiftLint passes for the changed files