### PR TITLE
Allow milestones without relationships

### DIFF
--- a/Sources/MusanovaKit/Music Summary/Milestones/MusicSummaryMilestone.swift
+++ b/Sources/MusanovaKit/Music Summary/Milestones/MusicSummaryMilestone.swift
@@ -84,10 +84,19 @@ public extension MusicSummaryMilestone {
     value = try attributesContainer.decode(String.self, forKey: .value)
     kind = try attributesContainer.decode(MusicSummaryMilestoneKind.self, forKey: .kind)
 
-    let relationshipsContainer = try container.nestedContainer(keyedBy: RelationshipsCodingKeys.self, forKey: .relationships)
-    topSongs = try relationshipsContainer.decodeIfPresent(Songs.self, forKey: .topSongs) ?? []
-    topAlbums = try relationshipsContainer.decodeIfPresent(Albums.self, forKey: .topAlbums) ?? []
-    topArtists = try relationshipsContainer.decodeIfPresent(Artists.self, forKey: .topArtists) ?? []
+    if container.contains(.relationships) {
+      let relationshipsContainer = try container.nestedContainer(
+        keyedBy: RelationshipsCodingKeys.self,
+        forKey: .relationships
+      )
+      topSongs = try relationshipsContainer.decodeIfPresent(Songs.self, forKey: .topSongs) ?? []
+      topAlbums = try relationshipsContainer.decodeIfPresent(Albums.self, forKey: .topAlbums) ?? []
+      topArtists = try relationshipsContainer.decodeIfPresent(Artists.self, forKey: .topArtists) ?? []
+    } else {
+      topSongs = []
+      topAlbums = []
+      topArtists = []
+    }
   }
 
   func encode(to encoder: Encoder) throws {

--- a/Tests/MusanovaKitTests/MusicSummariesMilestonesTests.swift
+++ b/Tests/MusanovaKitTests/MusicSummariesMilestonesTests.swift
@@ -14,6 +14,31 @@ import Testing
 @Suite
 struct MusicSummariesMilestonesTests {
   @Test
+  func decodesMilestoneWithoutRelationships() throws {
+    let data = Data(
+      #"""
+      {
+        "id": "year-2026-listen-time-minutes-2500",
+        "type": "music-summaries-milestones",
+        "attributes": {
+          "dateReached": "2026-03-26",
+          "kind": "listen-time",
+          "listenTimeInMinutes": 2901,
+          "value": "2500"
+        }
+      }
+      """#.utf8
+    )
+
+    let milestone = try JSONDecoder().decode(MusicSummaryMilestone.self, from: data)
+
+    #expect(milestone.id == "year-2026-listen-time-minutes-2500")
+    #expect(milestone.topSongs.isEmpty)
+    #expect(milestone.topAlbums.isEmpty)
+    #expect(milestone.topArtists.isEmpty)
+  }
+
+  @Test
   func testMusicSummariesMilestonesEndpointURL() throws {
     let request = try MusicSummaryMilestonesRequest(year: 2022, types: [], developerToken: "test_token")
     let endpointURL = try request.musicSummariesMilestonesEndpointURL


### PR DESCRIPTION
## What changed

Music summary milestones now decode with empty top-song, top-album, and top-artist collections when Apple omits the `relationships` container. The arrays were already optional inside the container; this makes the container itself optional too.

## Live evidence

The 2026 milestones endpoint returned 200 with seven resources. None included a `relationships` object, including listen-time, artist, and song milestones.

## Verification

- added a regression test from the current live shape
- 92 tests pass
- strict SwiftLint passes for both changed files