### PR TITLE
Add the macOS Musanova API Lab

### DIFF
--- a/Musanova/Musanova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Musanova/Musanova.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b46654a2163cd68406fb14597c82ca431e81a507f817c7f35021ec4ae91e3aaf",
+  "originHash" : "a6547de78e8f8dd335bdc1ceae366cce43f5a9445508321d39d4504a872d254b",
   "pins" : [
     {
       "identity" : "musadorakit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/MusadoraKit",
       "state" : {
-        "branch" : "main",
-        "revision" : "5743dbdab033324e0b066bf1194102ec4f3f02d0"
+        "revision" : "e7808ff4b4fc066dc6dbd4965288392677e68207",
+        "version" : "8.3.0"
       }
     }
   ],

--- a/Musanova/Musanova/API Lab/APIExample.swift
+++ b/Musanova/Musanova/API Lab/APIExample.swift
@@ -1,0 +1,95 @@
+//
+//  APIExample.swift
+//  Musanova
+//
+
+import Foundation
+
+enum APIExample: String, CaseIterable, Identifiable, Sendable {
+  case tastePreferences
+  case libraryPins
+  case lyrics
+  case replay
+  case concertHub
+  case concertDetail
+  case artistConcerts
+  case editorialRoom
+  case editorialMultiroom
+  case socialProfile
+  case followers
+  case followees
+  case pendingFollowers
+
+  var id: Self { self }
+
+  var title: String {
+    switch self {
+    case .tastePreferences: "Taste Preferences"
+    case .libraryPins: "Library Pins"
+    case .lyrics: "Syllable Lyrics"
+    case .replay: "Replay and Milestones"
+    case .concertHub: "Concert Hub"
+    case .concertDetail: "Concert Detail"
+    case .artistConcerts: "Artist Concerts"
+    case .editorialRoom: "Editorial Room"
+    case .editorialMultiroom: "Editorial Multiroom"
+    case .socialProfile: "Social Profile"
+    case .followers: "Followers"
+    case .followees: "Followees"
+    case .pendingFollowers: "Pending Followers"
+    }
+  }
+
+  var subtitle: String {
+    switch self {
+    case .tastePreferences: "Personalization signals"
+    case .libraryPins: "Pinned library resources"
+    case .lyrics: "Raw TTML and timed lines"
+    case .replay: "Available years and listening milestones"
+    case .concertHub: "Live concert sections"
+    case .concertDetail: "Dates, venues, artists, and tickets"
+    case .artistConcerts: "Upcoming concerts for one artist"
+    case .editorialRoom: "Mixed catalog content"
+    case .editorialMultiroom: "Editorial page sections"
+    case .socialProfile: "The signed-in profile"
+    case .followers: "Signed relationship read"
+    case .followees: "Signed relationship read"
+    case .pendingFollowers: "Signed relationship read"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .tastePreferences: "slider.horizontal.3"
+    case .libraryPins: "pin.fill"
+    case .lyrics: "quote.bubble.fill"
+    case .replay: "clock.arrow.circlepath"
+    case .concertHub, .concertDetail, .artistConcerts: "music.mic"
+    case .editorialRoom, .editorialMultiroom: "rectangle.3.group.fill"
+    case .socialProfile: "person.crop.circle"
+    case .followers, .followees, .pendingFollowers: "person.2.fill"
+    }
+  }
+
+  static let personal: [APIExample] = [
+    .tastePreferences,
+    .libraryPins,
+    .lyrics,
+    .replay
+  ]
+
+  static let discovery: [APIExample] = [
+    .concertHub,
+    .concertDetail,
+    .artistConcerts,
+    .editorialRoom,
+    .editorialMultiroom
+  ]
+
+  static let social: [APIExample] = [
+    .socialProfile,
+    .followers,
+    .followees,
+    .pendingFollowers
+  ]
+}

--- a/Musanova/Musanova/API Lab/APIExamplePhase.swift
+++ b/Musanova/Musanova/API Lab/APIExamplePhase.swift
@@ -1,0 +1,11 @@
+//
+//  APIExamplePhase.swift
+//  Musanova
+//
+
+enum APIExamplePhase: Equatable, Sendable {
+  case idle
+  case running
+  case succeeded
+  case failed
+}

--- a/Musanova/Musanova/API Lab/APIExampleResult.swift
+++ b/Musanova/Musanova/API Lab/APIExampleResult.swift
@@ -1,0 +1,9 @@
+//
+//  APIExampleResult.swift
+//  Musanova
+//
+
+struct APIExampleResult: Sendable {
+  var phase: APIExamplePhase = .idle
+  var detail = "Not run"
+}

--- a/Musanova/Musanova/API Lab/APIExampleRow.swift
+++ b/Musanova/Musanova/API Lab/APIExampleRow.swift
@@ -1,0 +1,64 @@
+//
+//  APIExampleRow.swift
+//  Musanova
+//
+
+import SwiftUI
+
+struct APIExampleRow: View {
+  let example: APIExample
+  let result: APIExampleResult
+  let run: () -> Void
+
+  var body: some View {
+    HStack(alignment: .top) {
+      Label {
+        VStack(alignment: .leading) {
+          Text(example.title)
+            .font(.headline)
+          Text(example.subtitle)
+            .foregroundStyle(.secondary)
+          Text(result.detail)
+            .font(.subheadline)
+            .foregroundStyle(result.phase == .failed ? Color.red : Color.secondary)
+            .textSelection(.enabled)
+        }
+      } icon: {
+        Image(systemName: example.systemImage)
+          .foregroundStyle(.purple)
+          .accessibilityHidden(true)
+      }
+
+      Spacer()
+
+      phaseIndicator
+
+      Button("Run", systemImage: "play.fill", action: run)
+        .labelStyle(.iconOnly)
+        .disabled(result.phase == .running)
+        .accessibilityLabel("Run \(example.title)")
+    }
+    .padding(.vertical, 4)
+  }
+
+  @ViewBuilder private var phaseIndicator: some View {
+    switch result.phase {
+    case .idle:
+      Image(systemName: "circle")
+        .foregroundStyle(.secondary)
+        .accessibilityLabel("Not run")
+    case .running:
+      ProgressView()
+        .controlSize(.small)
+        .accessibilityLabel("Running")
+    case .succeeded:
+      Image(systemName: "checkmark.circle.fill")
+        .foregroundStyle(.green)
+        .accessibilityLabel("Succeeded")
+    case .failed:
+      Image(systemName: "xmark.octagon.fill")
+        .foregroundStyle(.red)
+        .accessibilityLabel("Failed")
+    }
+  }
+}

--- a/Musanova/Musanova/API Lab/APIExampleSection.swift
+++ b/Musanova/Musanova/API Lab/APIExampleSection.swift
@@ -1,0 +1,30 @@
+//
+//  APIExampleSection.swift
+//  Musanova
+//
+
+import SwiftUI
+
+struct APIExampleSection: View {
+  let title: String
+  let examples: [APIExample]
+  let viewModel: APIExplorerViewModel
+
+  var body: some View {
+    Section(title) {
+      ForEach(examples) { example in
+        APIExampleRow(
+          example: example,
+          result: viewModel.result(for: example),
+          run: { run(example) }
+        )
+      }
+    }
+  }
+
+  private func run(_ example: APIExample) {
+    Task {
+      await viewModel.run(example)
+    }
+  }
+}

--- a/Musanova/Musanova/API Lab/APIExplorerView.swift
+++ b/Musanova/Musanova/API Lab/APIExplorerView.swift
@@ -1,0 +1,56 @@
+//
+//  APIExplorerView.swift
+//  Musanova
+//
+
+import SwiftUI
+
+struct APIExplorerView: View {
+  @State private var viewModel = APIExplorerViewModel()
+
+  var body: some View {
+    NavigationStack {
+      List {
+        Section {
+          LabeledContent("Apple Music", value: viewModel.isMusicAuthorized ? "Authorized" : "Not authorized")
+          LabeledContent("AMP token", value: viewModel.hasDeveloperToken ? "Ready" : "Missing")
+          Button("Run All Read APIs", systemImage: "play.fill", action: runAll)
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.isRunningAll)
+        } footer: {
+          Text("Runs safe reads only. Pin, unpin, reorder, and playback mutations stay manual.")
+        }
+
+        APIExampleSection(
+          title: "Personal",
+          examples: APIExample.personal,
+          viewModel: viewModel
+        )
+
+        APIExampleSection(
+          title: "Discovery",
+          examples: APIExample.discovery,
+          viewModel: viewModel
+        )
+
+        APIExampleSection(
+          title: "Social",
+          examples: APIExample.social,
+          viewModel: viewModel
+        )
+      }
+      .navigationTitle("API Lab")
+      .toolbar {
+        Button("Run All", systemImage: "play.fill", action: runAll)
+          .disabled(viewModel.isRunningAll)
+      }
+    }
+    .onAppear(perform: viewModel.refreshCredentials)
+  }
+
+  private func runAll() {
+    Task {
+      await viewModel.runAll()
+    }
+  }
+}

--- a/Musanova/Musanova/API Lab/APIExplorerViewModel.swift
+++ b/Musanova/Musanova/API Lab/APIExplorerViewModel.swift
@@ -1,0 +1,227 @@
+//
+//  APIExplorerViewModel.swift
+//  Musanova
+//
+
+import Foundation
+import MusanovaKit
+import MusicKit
+import Observation
+
+@MainActor
+@Observable
+final class APIExplorerViewModel {
+  private(set) var results: [APIExample: APIExampleResult]
+  private(set) var isRunningAll = false
+  private(set) var hasDeveloperToken = false
+  private(set) var isMusicAuthorized = false
+
+  private let storefront = "in"
+  private let artistID = "1462541757"
+  private let concertID = "ce.4f0d41eb-cedb-4f7b-bc2b-b9d7eab39a9e"
+  private let editorialRoomID = "1591131176"
+  private let editorialMultiroomID = "1591131185"
+  private let songID = MusicItemID("1837754303")
+
+  init() {
+    results = Dictionary(
+      uniqueKeysWithValues: APIExample.allCases.map { ($0, APIExampleResult()) }
+    )
+    refreshCredentials()
+  }
+
+  func refreshCredentials() {
+    hasDeveloperToken = developerToken?.isEmpty == false
+    isMusicAuthorized = MusicAuthorization.currentStatus == .authorized
+  }
+
+  func result(for example: APIExample) -> APIExampleResult {
+    results[example] ?? APIExampleResult()
+  }
+
+  func runAll() async {
+    guard !isRunningAll else { return }
+    isRunningAll = true
+    defer { isRunningAll = false }
+
+    for example in APIExample.allCases {
+      guard !Task.isCancelled else { return }
+      await run(example)
+    }
+  }
+
+  func run(_ example: APIExample) async {
+    refreshCredentials()
+    guard result(for: example).phase != .running else { return }
+    guard isMusicAuthorized else {
+      results[example] = APIExampleResult(
+        phase: .failed,
+        detail: "Apple Music access is not authorized."
+      )
+      return
+    }
+    guard let developerToken, !developerToken.isEmpty else {
+      results[example] = APIExampleResult(
+        phase: .failed,
+        detail: "Add the AMP token in Settings first."
+      )
+      return
+    }
+
+    results[example] = APIExampleResult(phase: .running, detail: "Contacting Apple Music…")
+
+    do {
+      results[example] = APIExampleResult(
+        phase: .succeeded,
+        detail: try await load(example, developerToken: developerToken)
+      )
+    } catch is CancellationError {
+      results[example] = APIExampleResult()
+    } catch {
+      results[example] = APIExampleResult(
+        phase: .failed,
+        detail: errorDetail(error)
+      )
+    }
+  }
+
+  private var developerToken: String? {
+    UserDefaults.standard.string(forKey: "developerToken")
+  }
+
+  private func errorDetail(_ error: any Error) -> String {
+    guard let musicError = error as? MusicDataRequest.Error else {
+      return error.localizedDescription
+    }
+    return "HTTP \(musicError.status) · \(musicError.code) \(musicError.title) · \(musicError.detailText)"
+  }
+
+  private func load(_ example: APIExample, developerToken: String) async throws -> String {
+    if APIExample.personal.contains(example) {
+      return try await loadPersonal(example, developerToken: developerToken)
+    }
+    if APIExample.discovery.contains(example) {
+      return try await loadDiscovery(example, developerToken: developerToken)
+    }
+    return try await loadSocial(example, developerToken: developerToken)
+  }
+
+  private func loadPersonal(_ example: APIExample, developerToken: String) async throws -> String {
+    switch example {
+    case .tastePreferences:
+      let preferences = try await MTaste.preferences(developerToken: developerToken)
+      let names = preferences.prefix(3).map(\.attributes.name).joined(separator: ", ")
+      return names.isEmpty
+        ? "200 OK · no expanded preferences"
+        : "200 OK · \(preferences.count) preferences · \(names)"
+
+    case .libraryPins:
+      let pins = try await MLibrary.pins(developerToken: developerToken, limit: 50)
+      let types = Set(pins.data.map(\.type)).sorted().joined(separator: ", ")
+      return "200 OK · \(pins.data.count) pins · \(types)"
+
+    case .lyrics:
+      let request = try MusicLyricsRequest(songID: songID, developerToken: developerToken)
+      let response = try await request.response(countryCode: storefront)
+      let characters = response.rawTTML?.count ?? 0
+      return "200 OK · \(response.data.count) resource · \(characters) TTML characters"
+
+    case .replay:
+      let summaries = Array(try await MSummaries.search(developerToken: developerToken))
+      guard let year = summaries.map(\.year).max() else {
+        return "200 OK · no Replay years"
+      }
+      let milestones = try await MSummaries.milestones(
+        forYear: MusicYearID(year),
+        developerToken: developerToken
+      )
+      return "200 OK · \(summaries.count) Replay years · \(milestones.count) milestones for \(year)"
+
+    default:
+      preconditionFailure("A non-personal example reached the personal loader.")
+    }
+  }
+
+  private func loadDiscovery(_ example: APIExample, developerToken: String) async throws -> String {
+    switch example {
+    case .concertHub:
+      let options = ConcertHubOptions(
+        containers: [.popular],
+        geoHashLocation: "dr5r",
+        limits: [.popular: 6]
+      )
+      let hub = try await MConcerts.hub(
+        storefront: storefront,
+        developerToken: developerToken,
+        options: options
+      )
+      let concertCount = hub.orderedContainers.reduce(0) { $0 + $1.data.count }
+      return "200 OK · \(hub.orderedContainers.count) sections · \(concertCount) concerts"
+
+    case .concertDetail:
+      let concert = try await MConcerts.concert(
+        id: concertID,
+        storefront: storefront,
+        developerToken: developerToken
+      )
+      let venues = concert.relationships?.venues?.data.count ?? 0
+      let tickets = concert.attributes.tickets?.count ?? 0
+      return "200 OK · \(concert.attributes.name) · \(venues) venue · \(tickets) tickets"
+
+    case .artistConcerts:
+      let concerts = try await MConcerts.upcomingConcerts(
+        forArtistID: artistID,
+        storefront: storefront,
+        limit: 10,
+        developerToken: developerToken
+      )
+      return "200 OK · \(concerts.artistName ?? artistID) · \(concerts.all.data.count) upcoming"
+
+    case .editorialRoom:
+      let room = try await MEditorial.room(
+        id: editorialRoomID,
+        storefront: storefront,
+        developerToken: developerToken
+      )
+      return "200 OK · \(room.attributes.title ?? room.id) · \(room.contents.count) resources"
+
+    case .editorialMultiroom:
+      let multiroom = try await MEditorial.multiroom(
+        id: editorialMultiroomID,
+        storefront: storefront,
+        developerToken: developerToken
+      )
+      let title = multiroom.attributes.uber?.name ?? multiroom.id
+      return "200 OK · \(title) · \(multiroom.children.count) sections"
+
+    default:
+      preconditionFailure("A non-discovery example reached the discovery loader.")
+    }
+  }
+
+  private func loadSocial(_ example: APIExample, developerToken: String) async throws -> String {
+    switch example {
+    case .socialProfile:
+      let profile = try await MSocial.profile(developerToken: developerToken)
+      let name = profile.socialProfile?.attributes?.name
+        ?? profile.attributes?.name
+        ?? profile.id
+      return "200 OK · \(name)"
+
+    case .followers:
+      let page = try await MSocial.followers(developerToken: developerToken)
+      return "Signed request accepted · \(page.profiles.count) followers"
+
+    case .followees:
+      let page = try await MSocial.followees(developerToken: developerToken)
+      return "Signed request accepted · \(page.profiles.count) followees"
+
+    case .pendingFollowers:
+      let page = try await MSocial.pendingFollowers(developerToken: developerToken)
+      return "Signed request accepted · \(page.profiles.count) pending"
+
+    default:
+      preconditionFailure("A non-social example reached the social loader.")
+    }
+  }
+}

--- a/Musanova/Musanova/Lyrics/LyricsView.swift
+++ b/Musanova/Musanova/Lyrics/LyricsView.swift
@@ -244,6 +244,8 @@ struct LyricsView: View {
                     errorMessage = "Developer token is required. Please set it in Settings."
                 case .countryCodeUnavailable:
                     errorMessage = "Unable to determine country code."
+                case .requestSigningFailed(let description):
+                    errorMessage = "Request signing failed: \(description)"
                 }
             } catch {
                 print("[Lyrics] Unexpected error: \(error)")

--- a/Musanova/Musanova/Main/MTabView.swift
+++ b/Musanova/Musanova/Main/MTabView.swift
@@ -10,25 +10,25 @@ import SwiftUI
 struct MTabView: View {
   var body: some View {
     TabView {
-      ReplayView()
-        .tabItem {
-          Label("Replay", systemImage: "clock.arrow.circlepath")
-        }
+      Tab("API Lab", systemImage: "testtube.2") {
+        APIExplorerView()
+      }
 
-      LyricsView()
-        .tabItem {
-          Label("Lyrics", systemImage: "music.note")
-        }
+      Tab("Replay", systemImage: "clock.arrow.circlepath") {
+        ReplayView()
+      }
 
-      PinsView()
-        .tabItem {
-          Label("Pins", systemImage: "pin")
-        }
+      Tab("Lyrics", systemImage: "music.note") {
+        LyricsView()
+      }
 
-      SettingsView()
-        .tabItem {
-          Label("Settings", systemImage: "gear")
-        }
+      Tab("Pins", systemImage: "pin") {
+        PinsView()
+      }
+
+      Tab("Settings", systemImage: "gear") {
+        SettingsView()
+      }
     }
     .welcomeSheet()
     .tint(.purple)

--- a/Musanova/Musanova/Settings/SettingsView.swift
+++ b/Musanova/Musanova/Settings/SettingsView.swift
@@ -16,13 +16,13 @@ struct SettingsView: View {
       List {
         Section("Developer Token") {
           VStack(alignment: .leading, spacing: 8) {
-            Text("Enter your Apple Music developer token to access private APIs like pins and lyrics.")
+            Text("Enter the AMP developer token used by the private API examples.")
               .font(.subheadline)
-              .foregroundColor(.secondary)
+              .foregroundStyle(.secondary)
 
-            TextField("Developer Token", text: $developerToken)
+            SecureField("Developer Token", text: $developerToken)
               .textFieldStyle(.roundedBorder)
-              .autocorrectionDisabled()
+              .privacySensitive()
 
             Button("Save Token") {
               UserDefaults.standard.set(developerToken, forKey: "developerToken")
@@ -43,7 +43,7 @@ struct SettingsView: View {
       .alert("Token Saved", isPresented: $showTokenSavedAlert) {
         Button("OK", role: .cancel) { }
       } message: {
-        Text("Your developer token has been saved securely.")
+        Text("Your developer token has been saved on this Mac.")
       }
     }
     .tint(Color.indigo)

--- a/Musanova/README.md
+++ b/Musanova/README.md
@@ -1,11 +1,17 @@
-# Musadora 
+# Musanova
 
-Musadora is a sample project to show all the methods and powers of MusadoraKit. It is work in progress right now. 
+Musanova is a sample app for trying MusanovaKit against a signed-in Apple Music account.
 
-## Installation 
+## Setup
 
-You can change the bundle identifier to something of your own that has MusicKit services enabled. Then, build the project on your phone. 
+Use a bundle identifier with MusicKit enabled, then build the app with your Apple Development team. Add the AMP developer token in Settings; the token is not part of the repository.
 
-## Playing Music 
+## API Lab
 
-Just long press on music items to start playing it.
+The macOS API Lab runs every safe read example individually or as one sequence:
+
+- taste preferences, library pins, lyrics, Replay, and milestones
+- concert hub, concert detail, artist concerts, editorial rooms, and multirooms
+- social profile, followers, followees, and pending followers
+
+Pin, unpin, reorder, and playback mutations are not included in Run All because they change the account.


### PR DESCRIPTION
## What changed

- add a macOS API Lab tab with individual Run buttons and a safe Run All sequence
- cover taste, pins, lyrics, Replay, milestones, concerts, editorial rooms, social profile, and signed social relationships
- use the working web-shaped concert hub request with a geohash
- show authorization, token readiness, per-endpoint progress, response summaries, and full errors
- keep pin/unpin/reorder and playback mutations out of Run All
- hide the AMP token in Settings and refresh credential state when returning to the lab

## Live macOS verification

Built and signed with the local Apple Development identity, pasted the AMP token through Settings, and ran the app with MusicKit authorized on the current account. All 13 examples succeeded:

- 21 taste preferences
- 3 library pins
- 1 lyrics resource with 31,589 TTML characters
- 3 Replay years and 7 milestones
- 6 concert-hub results
- concert detail with venue and ticket data
- 10 upcoming artist concerts
- editorial room with 22 resources
- editorial multiroom with 17 sections
- social profile returned 200
- followers, followees, and pending followers passed Mescal signing and returned empty collections

No developer token, media-user token, DSID, or action signature is committed.

## Verification

- signed macOS Xcode build succeeds
- 92 package tests pass on merged main
- strict SwiftLint passes for the API Lab, tab, and Settings files